### PR TITLE
v2.2.2 — safety hardening + form UX fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ tests/experiments/v16-results.tsv
 docs/FORM-PROTOCOL.md
 docs/v2.1.0-multipart-kits-plan.md
 docs/2026-*-*.md
+*.egg-info/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,53 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2.2.2] — 2026-07-06
+
+Safety hardening plus two operator-reported UX bugs, verified live on real
+hardware (gemma4-26b over Telegram): a full kit ran form → slice → previews →
+bed-clear → grace window → operator cancel, with every fix engaged.
+
+### Safety
+
+- **Stage-2 nonce consumption fails CLOSED.** Any failure while consuming the
+  single-use start nonce (lock, read, or write error) now refuses the start
+  instead of authorizing it. The previous best-effort fallback returned success
+  on error, which is exactly backwards for a safety gate.
+- **The material-mismatch override enforces its interactive-terminal requirement
+  at the point the override is applied**, not only in the CLI entrypoint, so a
+  direct programmatic caller cannot honor the override without a TTY either.
+- **Each detached start-gate launch gets a unique run id** for its state marker
+  and log, so overlapping invocations for one request can never cross-talk or
+  misattribute a grace window.
+- **Form answers are claimed before they are read** (atomic rename first), so
+  concurrent redeems of one submission cannot both act on it.
+
+### Fixed
+
+- **Duplicate copies of one model now all render in the 3D plate view.** The
+  renderer keyed geometry by base model name, which collapsed copies into one
+  part while the top-down drew both; geometry is now keyed by the full per-part
+  instance id, with copies sharing a color.
+- **Re-editing a completed form no longer traps the operator.** Editing a field
+  from the Review screen and advancing used to march forward through the
+  remaining screens (or dead-end with no way to confirm); it now returns
+  straight to Review.
+- **A duplicated redeem command re-surfaces the bed-clear prompt** (same
+  still-valid confirm token) instead of re-rendering a fresh form — a relayed
+  duplicate is now a harmless no-op.
+
+### Changed
+
+- **The `snapmaker_u1` gateway plugin is now tracked in-repo** (`plugin/`,
+  installed with `pip install -e ./plugin/`). It auto-loads the slicing skill
+  when a 3D-model attachment arrives and wraps `next_action_required` output in
+  a hard directive so a small model tool-calls the command verbatim. It was
+  previously an untracked local directory — runtime-critical but invisible to
+  version control, which let it silently disappear and take the whole
+  attachment-to-skill flow with it.
+
+---
+
 ## [2.2.1] — 2026-07-06
 
 A safety-hardening and preview-fidelity patch on top of v2.2.0, closing several

--- a/adapters/telegram/u1_form_telegram.py
+++ b/adapters/telegram/u1_form_telegram.py
@@ -417,6 +417,10 @@ def _apply_callback_inner(form: dict[str, Any], data: str) -> dict[str, Any]:
     fid = field["id"]
 
     if kind == "e":
+        # Edit-from-review: remember to return to Review after this field, so a
+        # tweak doesn't march the operator forward through the remaining screens
+        # (or dead-end). Cleared when the edited screen advances.
+        form["_edit_return"] = True
         form["current"] = fid
         return {"kind": "rerender"}
 
@@ -442,8 +446,10 @@ def _apply_callback_inner(form: dict[str, Any], data: str) -> dict[str, Any]:
         return {"kind": "rerender"}
 
     if kind == "n":
-        # Done on a multi field → advance to next
-        form["current"] = _next_field(form)
+        # Done on a multi field (or a group's shared Next) → advance. If we got
+        # here via Edit-from-review, go straight back to Review instead of
+        # marching forward through the remaining screens.
+        form["current"] = REVIEW_FIELD if form.pop("_edit_return", None) else _next_field(form)
         return {"kind": "rerender"}
 
     if kind == "s":
@@ -455,7 +461,7 @@ def _apply_callback_inner(form: dict[str, Any], data: str) -> dict[str, Any]:
         # A single-select on its own screen advances on tap; one inside a
         # group is a radio — it only marks, the shared Next advances.
         if not field.get("group"):
-            form["current"] = _next_field(form)
+            form["current"] = REVIEW_FIELD if form.pop("_edit_return", None) else _next_field(form)
         return {"kind": "rerender"}
 
     raise ValueError(f"bad callback_data: {data!r}")

--- a/plugin/plugin.yaml
+++ b/plugin/plugin.yaml
@@ -1,0 +1,8 @@
+name: snapmaker_u1
+version: 0.1.0
+description: Auto-trigger the Snapmaker U1 slicing skill on STL/3MF/ZIP attachments.
+provides_hooks:
+  - pre_gateway_dispatch
+  - transform_tool_result
+provides_skills:
+  - 3d-printer-slicing-automation

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "snapmaker-u1-toolkit-plugin"
+version = "0.1.0"
+description = "Hermes plugin: auto-trigger the snapmaker U1 3D-printer-slicing skill on STL/3MF/ZIP attachments. Wraps the existing snapmaker-u1-toolkit skill + scripts."
+license = {text = "MIT"}
+requires-python = ">=3.11"
+authors = [{name = "Brent Bolinger"}]
+keywords = ["hermes-agent", "snapmaker", "3d-printing", "klipper", "moonraker", "plugin"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+]
+dependencies = []
+
+[project.entry-points."hermes_agent.plugins"]
+snapmaker_u1 = "snapmaker_u1"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+snapmaker_u1 = ["*.md", "skills/**/*.md"]

--- a/plugin/src/snapmaker_u1/__init__.py
+++ b/plugin/src/snapmaker_u1/__init__.py
@@ -1,0 +1,116 @@
+"""snapmaker_u1 — Hermes plugin: auto-trigger the U1 slicing skill on 3D-model attachments.
+
+Why this exists: a small local model can't be trusted to remember to load the
+right skill when a print job arrives. This plugin makes that mechanical.
+
+Architecture (hermes-agent v0.17):
+
+  1. Plugin registers a `pre_gateway_dispatch` hook.
+  2. On each inbound MessageEvent, the hook checks the raw attachment filename
+     and the visible message text for a 3D-model extension (.stl / .3mf / .zip).
+  3. When matched, the hook sets `event.auto_skill = "3d-printer-slicing-automation"`
+     (or, if the bundled skill is registered, `snapmaker_u1:3d-printer-slicing-automation`).
+  4. The gateway's existing auto-skill plumbing injects the full SKILL.md body
+     as the first user message of the session — the same path topic-bound
+     skills use. The model sees the entire skill from turn 1, no `skill_view`
+     round-trip needed.
+
+Skill discovery:
+  Plugin-bundled SKILL.md first (the namespaced form); falls back to the
+  deployed copy under ~/.hermes/skills (where deploy_to_runtime.sh puts it).
+  This keeps the plugin pip-installable while matching the standard deploy.
+
+Distribution: `pip install -e ./plugin/` from the repo root.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Skill we trigger
+SKILL_NAME = "3d-printer-slicing-automation"
+
+# Candidate paths to the SKILL.md, in priority order.
+# - First entry: bundled inside the plugin package (for distribution)
+# - Fallback: the standard deployed location (deploy_to_runtime.sh)
+_PLUGIN_SKILL_DIR = Path(__file__).resolve().parent / "skills" / SKILL_NAME
+_DEPLOYED_SKILL_DIR = Path("/opt/data/skills/hardware-automation") / SKILL_NAME
+
+
+def _resolve_skill_path() -> Path | None:
+    """Return the first SKILL.md path that exists, or None if neither does."""
+    for d in (_PLUGIN_SKILL_DIR, _DEPLOYED_SKILL_DIR):
+        candidate = d / "SKILL.md"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def register(ctx: Any) -> None:
+    """Plugin entry point. Called by Hermes' plugin manager on startup."""
+    from .hooks.attachment_router import make_handler
+
+    skill_path = _resolve_skill_path()
+    skill_identifier = SKILL_NAME  # default: flat name (deployed in ~/.hermes/skills/)
+
+    if skill_path and skill_path.parent == _PLUGIN_SKILL_DIR:
+        # Bundled version found — register it via plugin namespacing.
+        try:
+            ctx.register_skill(
+                SKILL_NAME,
+                skill_path,
+                description=(
+                    "Snapmaker U1 staged slicing workflow (orient → render → slice → "
+                    "upload → camera-gated start). Plugin-bundled."
+                ),
+            )
+            # Namespaced identifier — gateway's _load_skill_payload → skill_view
+            # resolves `<plugin>:<skill>` per tools/skills_tool.py docstring.
+            skill_identifier = "snapmaker_u1:" + SKILL_NAME
+            logger.info(
+                "snapmaker_u1 plugin: registered bundled skill %r at %s",
+                skill_identifier, skill_path,
+            )
+        except Exception as exc:
+            logger.warning(
+                "snapmaker_u1 plugin: register_skill failed (%s); falling back to "
+                "deployed copy via flat name '%s'", exc, SKILL_NAME,
+            )
+            skill_identifier = SKILL_NAME
+
+    elif skill_path:
+        logger.info(
+            "snapmaker_u1 plugin: using deployed SKILL.md at %s (skill auto-load "
+            "will resolve flat name '%s' via the index)", skill_path, SKILL_NAME,
+        )
+    else:
+        logger.warning(
+            "snapmaker_u1 plugin: SKILL.md not found in plugin bundle (%s) OR at "
+            "deployed path (%s). Hook will still set auto_skill='%s' but Hermes "
+            "may log 'Auto-skill not found' at session start.",
+            _PLUGIN_SKILL_DIR, _DEPLOYED_SKILL_DIR, SKILL_NAME,
+        )
+
+    # Register the attachment-detection hook with the resolved skill identifier.
+    handler = make_handler(skill_identifier)
+    ctx.register_hook("pre_gateway_dispatch", handler)
+    logger.info(
+        "snapmaker_u1 plugin: pre_gateway_dispatch hook registered (skill='%s')",
+        skill_identifier,
+    )
+
+    # Register the transform_tool_result hook that prevents anti-pattern #7
+    # (Gemma printing next_action_required.command as text instead of
+    # tool-calling it). Observed live 2026-06-29 in session
+    # 20260629_220708_5e63b52f; hook prepends a strongly directive prefix to
+    # the terminal tool output when it contains a next_action_required event.
+    from .hooks.next_action_directive import transform as next_action_transform
+    ctx.register_hook("transform_tool_result", next_action_transform)
+    logger.info(
+        "snapmaker_u1 plugin: transform_tool_result hook registered "
+        "(next_action_required directive)",
+    )

--- a/plugin/src/snapmaker_u1/hooks/__init__.py
+++ b/plugin/src/snapmaker_u1/hooks/__init__.py
@@ -1,0 +1,1 @@
+"""snapmaker_u1.hooks — gateway hook handlers."""

--- a/plugin/src/snapmaker_u1/hooks/attachment_router.py
+++ b/plugin/src/snapmaker_u1/hooks/attachment_router.py
@@ -1,0 +1,94 @@
+"""pre_gateway_dispatch hook — set event.auto_skill when a 3D-model attachment arrives.
+
+Verified behavior (hermes-agent v0.17):
+  * MessageEvent is @dataclass WITHOUT frozen=True → mutable.
+  * The gateway calls `invoke_hook("pre_gateway_dispatch", event=event, ...)`
+    BEFORE auth + agent dispatch.
+  * A hook can mutate the event in place; the gateway's later auto-skill loader
+    reads `getattr(event, "auto_skill", None)` and injects the skill body as
+    the first user message of the session (the same plumbing topic-bound
+    skills use).
+
+What we detect (in order of confidence):
+  1. The Telegram-shape attachment template Hermes injects when a document is
+     received: ``[The user sent a document: 'name.zip'. It is saved at: <path>]``
+  2. Generic file-extension matches anywhere in the visible message text
+     (fallback for other platforms / pasted paths). Word-boundary keeps us
+     from matching ``stl_pipeline.py`` or similar false positives.
+
+Conservative scope:
+  * We only mutate `auto_skill` when it's currently unset — if a topic binding
+    or another upstream hook already chose a skill, we don't overwrite.
+  * We return None so dispatch continues normally (we're not blocking/rewriting
+    the message itself — just setting an attribute the loader reads later).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+# Matches the canonical Telegram attachment text Hermes injects + any bare
+# .stl/.3mf/.zip reference in the message body. Word-boundary `\b` keeps
+# us from matching "stl_pipeline.py" or similar false positives.
+_ATTACHMENT_RE = re.compile(r"\.(stl|3mf|zip)\b", re.IGNORECASE)
+
+
+def make_handler(skill_identifier: str) -> Callable[..., Any]:
+    """Build the pre_gateway_dispatch handler with the resolved skill identifier baked in.
+
+    Args:
+        skill_identifier: either `"<flat-name>"` (loaded from ~/.hermes/skills/)
+                          or `"<plugin>:<skill>"` (plugin-namespaced).
+                          The gateway's _load_skill_payload + skill_view chain
+                          resolves both forms.
+    """
+
+    def handler(event: Any = None, gateway: Any = None, session_store: Any = None,
+                **kwargs: Any):
+        if event is None:
+            return None
+        try:
+            _text = getattr(event, "text", "") or ""
+            _raw = getattr(event, "raw_message", None)
+            _has_doc = bool(_raw) and hasattr(_raw, "document") and _raw.document is not None
+            _doc_name = getattr(_raw.document, "file_name", None) if _has_doc else None
+            logger.debug(
+                "snapmaker_u1 attachment_router: text_len=%d has_doc=%s doc_name=%r "
+                "current_auto_skill=%r",
+                len(_text), _has_doc, _doc_name, getattr(event, "auto_skill", None),
+            )
+        except Exception as _exc:
+            logger.warning("snapmaker_u1 attachment_router: event inspect failed: %s", _exc)
+            _text = ""
+            _has_doc = False
+            _doc_name = None
+        # Don't overwrite an already-set auto_skill.
+        if getattr(event, "auto_skill", None):
+            return None
+        # Try BOTH the visible text (post-template) and the raw document
+        # filename (pre-template): the hook fires before Hermes injects the
+        # attachment template, so the filename match is the one that lands on
+        # Telegram; the text regex covers other platforms and pasted paths.
+        matched_by = None
+        if _text and _ATTACHMENT_RE.search(_text):
+            matched_by = "text-regex"
+        elif _doc_name and _ATTACHMENT_RE.search(_doc_name):
+            matched_by = "doc-filename"
+        if not matched_by:
+            return None
+        try:
+            event.auto_skill = skill_identifier
+            logger.info(
+                "snapmaker_u1 attachment_router: set event.auto_skill=%r (via %s)",
+                skill_identifier, matched_by,
+            )
+        except Exception as exc:
+            logger.warning(
+                "snapmaker_u1 attachment_router: failed to set auto_skill: %s", exc,
+            )
+        return None  # let dispatch continue normally
+    return handler

--- a/plugin/src/snapmaker_u1/hooks/next_action_directive.py
+++ b/plugin/src/snapmaker_u1/hooks/next_action_directive.py
@@ -1,0 +1,110 @@
+"""transform_tool_result hook — harden Gemma against anti-pattern #7.
+
+The kit workflow emits a `next_action_required` event when it needs the agent
+to run the Stage 1 photo-gate command. Observed failure (session
+20260629_220708_5e63b52f, 2026-06-29): gemma4-26b-64k printed the command
+verbatim as TEXT in its reply (anti-pattern #7 in SKILL.md) AND fabricated a
+typo in the request_id (`u1_2026_0603_…` vs the actual `u1_2026_0630_…`).
+Stage 1 never ran.
+
+This hook intercepts the `terminal` tool result and, when the result contains
+a `next_action_required` event with a `command` field, prepends a strongly
+directive prefix to the tool output the agent reads. The directive tells the
+agent in unmissable language that the command must be tool-called via
+terminal (NOT printed as text), and that the request_id must be copied
+verbatim (NOT regenerated).
+
+VALID_MIDDLEWARE includes TOOL_EXECUTION_MIDDLEWARE, but `transform_tool_result`
+is the documented hook for adjusting tool results between agent rounds
+(verified at hermes_cli/plugins.py:128). First non-None return wins.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Match the JSON-events line emitted by the kit/single-STL workflows.
+# Lines are individual JSON objects, one per line, in the tool output's "output"
+# field. We look for `"stage": "next_action_required"` with a `"command":` value.
+_NEXT_ACTION_RE = re.compile(
+    r'"stage"\s*:\s*"next_action_required".*?"command"\s*:\s*"([^"]+)"',
+    re.DOTALL,
+)
+_REQUEST_ID_RE = re.compile(r"u1_\d{4}_\d{4}_[a-f0-9]+")
+
+
+def transform(tool_name: str = "", args: Any = None, result: Any = None,
+              **kwargs: Any) -> Any:
+    """Wrap workflow output containing next_action_required with directive prefix."""
+    if tool_name != "terminal":
+        return None  # only target terminal tool output
+    if not result:
+        return None
+    # The terminal tool result is a JSON-stringified dict or a dict.
+    # We look at the "output" field which contains the workflow stdout.
+    try:
+        if isinstance(result, str):
+            result_dict = json.loads(result)
+        elif isinstance(result, dict):
+            result_dict = result
+        else:
+            return None
+    except (ValueError, TypeError):
+        return None
+    output = result_dict.get("output", "") or ""
+    if not output or "next_action_required" not in output:
+        return None
+    m = _NEXT_ACTION_RE.search(output)
+    if not m:
+        return None
+    command = m.group(1)
+    # Extract the canonical request_id from the command for the directive
+    rid_match = _REQUEST_ID_RE.search(command)
+    canonical_rid = rid_match.group(0) if rid_match else None
+
+    directive_parts = [
+        "[CRITICAL — DO NOT IGNORE THIS DIRECTIVE]",
+        "The workflow has emitted a `next_action_required` event below.",
+        "Your IMMEDIATE next tool call MUST be the `terminal` tool with the",
+        "EXACT `command` shown — verbatim, no edits, no paraphrase.",
+        "",
+        f"  command: {command}",
+        "",
+    ]
+    if canonical_rid:
+        directive_parts.append(
+            f"The `request_id` in that command is `{canonical_rid}`. "
+            "Copy it CHARACTER-FOR-CHARACTER. Do NOT regenerate, do NOT alter "
+            "the date digits, do NOT make a new ID."
+        )
+        directive_parts.append("")
+    directive_parts.extend([
+        "Anti-patterns this directive blocks (see SKILL.md):",
+        "  #7 — Printing the command as text instead of tool-calling it. NEVER do this.",
+        "  #4 — State-from-chat-memory: do NOT compose the command from memory; use the verbatim string above.",
+        "  #6 — Verification fabrication: do NOT fabricate or 'fix' the request_id.",
+        "",
+        "After the terminal tool call returns, follow Step 4 of the skill",
+        "(surface the snapshot.path, ask for the operator's yes/no).",
+        "",
+        "===== ORIGINAL WORKFLOW OUTPUT FOLLOWS =====",
+        output,
+    ])
+    new_output = "\n".join(directive_parts)
+    result_dict["output"] = new_output
+    logger.info(
+        "snapmaker_u1 next_action_directive: wrapped %d-char terminal output "
+        "with anti-pattern-#7 directive (canonical_rid=%s)",
+        len(output), canonical_rid,
+    )
+    # Return must match the original result shape. terminal results are
+    # serialized JSON strings in registry dispatch; pass back a string if we
+    # got a string, dict if we got a dict.
+    if isinstance(result, str):
+        return json.dumps(result_dict, ensure_ascii=False)
+    return result_dict

--- a/scripts/u1_form.py
+++ b/scripts/u1_form.py
@@ -614,17 +614,30 @@ def write_answers_file(form_id: str, obj: dict) -> "Path":
 
 
 def read_and_consume_answers(form_id: str) -> dict:
-    """Read an answer file and consume it (single-use — renamed on read so
-    a replayed --form-answers-from redeems nothing). Raises FileNotFoundError
-    when absent/already consumed and ValueError on a bad id or bad JSON."""
+    """Read an answer file and consume it (single-use). Raises FileNotFoundError
+    when absent/already consumed and ValueError on a bad id or bad JSON.
+
+    v2.2.2: CLAIM-before-read. The file is atomically renamed to a pid-unique
+    path BEFORE it is read, so two concurrent redeems (double delivery / retry)
+    cannot both read the same file and both act on it (the old read-then-rename
+    let both in). Only the process whose ``os.replace`` wins owns the answers;
+    the loser sees the source gone and raises FileNotFoundError."""
     import json as _json
     import os
     p = _answers_path(form_id)
-    if not p.is_file():
+    claimed = p.with_suffix(f".claimed.{os.getpid()}")
+    try:
+        os.replace(p, claimed)
+    except OSError:
         raise FileNotFoundError(
             f"no pending answers for form {form_id!r} (missing or already used)")
-    text = p.read_text()
-    os.replace(p, p.with_suffix(".json.consumed"))
+    try:
+        text = claimed.read_text()
+    finally:
+        try:
+            os.replace(claimed, p.with_suffix(".json.consumed"))
+        except OSError:
+            pass
     obj = _json.loads(text)
     if not isinstance(obj, dict):
         raise ValueError("answers file must contain a JSON object")

--- a/scripts/u1_kit_workflow.py
+++ b/scripts/u1_kit_workflow.py
@@ -2277,6 +2277,51 @@ def run_kit_workflow(args) -> dict[str, Any]:
     answers = getattr(args, "form_answers", None)
     answers_json = getattr(args, "form_answers_json", None)
     answers_from = getattr(args, "form_answers_from", None)
+    # v2.2.2: idempotency for a DUPLICATE form-redeem. If the request already
+    # advanced to the bed-clear step (the first redeem sliced + uploaded and is
+    # awaiting the operator's yes), a second --redeem-pending-form must NOT
+    # re-render a fresh form — that stranded the operator in a form loop when a
+    # small model relayed the redeem command twice (live 2026-07-06). Re-surface
+    # the SAME bed-clear prompt (same still-valid confirm token) instead, so the
+    # duplicate relay is a harmless no-op.
+    if (getattr(args, "redeem_pending_form", False)
+            and not getattr(args, "action", None)):
+        # Detect the already-advanced state by the DURABLE pending object, NOT
+        # the phase: the looping re-form reset phase to awaiting_form while the
+        # pending_bed_clear_start (nonce + confirm token) survived in safety
+        # (confirmed on the live 2026-07-06 request).
+        _idem_safety = (u1_request.read_request(request_id) or {}).get("safety") or {}
+        _idem_pending = _idem_safety.get("pending_bed_clear_start") or {}
+        _idem_tok = _idem_pending.get("confirm_token")
+        if _idem_pending.get("nonce") and _idem_tok:
+            _idem_prompt = (
+                "You already submitted this plate — it's sliced, uploaded, and "
+                "waiting on your bed-clear yes. Reply YES to start now, or NO to "
+                "keep the gcode staged without printing.")
+            _emit(events_file, {
+                "stage": "need_input", "request_id": request_id,
+                "need": "bed_clear_start", "key": "bed_clear_start",
+                "requires_fresh_operator_bed_clear": True,
+                "approval_prompt_key": "bed_clear_start",
+                "prompt": _idem_prompt,
+                "instruction": ("The plate preview + bed photo were already sent "
+                                "on the previous turn — do NOT re-run the form. "
+                                "Re-surface the yes/no prompt and wait."),
+                "expected_answers": ["yes", "no"],
+                "next_command_on_yes": (
+                    f"python3 /opt/data/scripts/u1_kit_workflow.py "
+                    f"--confirm-start {_idem_tok}"),
+                "next_command_on_no": None,
+                "bed_snapshot_path": (_idem_safety.get("snapshot_path")
+                                      or _idem_safety.get("bed_snapshot_path")),
+            }, json_events)
+            _emit(events_file, {"stage": "awaiting_input",
+                                "need": "bed_clear_start",
+                                "request_id": request_id}, json_events)
+            _audit(request_id, "duplicate_redeem_reemitted_bed_clear", operator)
+            return {"phase": "awaiting_bed_clear_start",
+                    "request_id": request_id, "prompt": _idem_prompt}
+
     if getattr(args, "redeem_pending_form", False) and not answers_from:
         # The model relays NO form_id — it derives from the request, which
         # persisted form_id at emit time. gemma4 mangled the random-hex form_id

--- a/scripts/u1_kit_workflow.py
+++ b/scripts/u1_kit_workflow.py
@@ -1068,6 +1068,7 @@ def _render_plate_isometric_from_gcode(
     id_to_name: dict[int, str] = {}
     layers: dict[str, dict[float, list]] = defaultdict(lambda: defaultdict(list))
     heights: dict[str, float] = defaultdict(float)
+    base_of: dict[str, str] = {}  # v2.2.2: instance name -> base model name (shared color)
     cid = None; cbase = None; ctype = None; prevx = prevy = None; cz = 0.0
     poly: list[tuple[float, float]] = []
 
@@ -1087,7 +1088,16 @@ def _render_plate_isometric_from_gcode(
         if ms:
             flush(); nid = int(ms.group(1)); cid = None if nid < 0 else nid; cbase = None
             if cid is not None:
-                nm = id_to_name.get(cid, ""); cbase = re.sub(r"_id_\d+_copy_\d+$", "", nm) or None
+                nm = id_to_name.get(cid, "")
+                # v2.2.2: key geometry by the FULL M486 instance name so two
+                # copies of one model (same base, distinct _id_/_copy_) each keep
+                # their own polygons and position. Keying by the stripped base
+                # collapsed copies into one part in the 3D view (the largest-loop
+                # pick below) while the top-down drew both, so the two review
+                # images disagreed. Base name is kept only for a shared color.
+                cbase = nm or None
+                if cbase is not None:
+                    base_of[cbase] = re.sub(r"_id_\d+_copy_\d+$", "", nm) or cbase
             continue
         zm = Z_RE.search(ln)
         if zm:
@@ -1177,13 +1187,18 @@ def _render_plate_isometric_from_gcode(
         "from the real sliced gcode (matches the footprint)"
     d.text((pad, 52), sub, fill=(140, 150, 160), font=small_font)
     n = len(parts)
+    # v2.2.2: colour by base model, not by instance, so copies of one model
+    # share a hue (and distinct models stay distinct) even though each instance
+    # is now drawn separately.
+    _bases = sorted({base_of.get(p, p) for p in parts})
+    _base_idx = {b: k for k, b in enumerate(_bases)}
+    _nb = len(_bases)
 
     def _depth(p):  # draw parts further back (higher y) first
         lp = rep[p]; return -sum(b for _, b in lp) / len(lp)
 
     for p in sorted(parts, key=_depth):
-        i = parts.index(p)
-        r, g, b = colorsys.hsv_to_rgb(i / max(n, 1), 0.55, 0.9)  # match top-down
+        r, g, b = colorsys.hsv_to_rgb(_base_idx[base_of.get(p, p)] / max(_nb, 1), 0.55, 0.9)
         bright = (int(r * 255), int(g * 255), int(b * 255))
         dim = tuple(int(c * 0.5) for c in bright)
         h = max(heights[p], 1.0); lp = rep[p]
@@ -2013,19 +2028,18 @@ def _invoke_stage2_gate(gate_py: str, argv: list[str], out_dir):
     Isolated so tests monkeypatch it (never contact Moonraker / block)."""
     from types import SimpleNamespace
     out_dir = Path(out_dir)
-    # #4: per-invocation log so a retry can't truncate a live gate's diagnostics.
-    log_path = out_dir / f"stage2_gate_{os.getpid()}.log"
-    state_path = out_dir / "stage2_gate_state.json"
-    # Clear any stale marker from a prior invocation BEFORE launching, so we only
-    # ever observe THIS child's transitions.
-    try:
-        state_path.unlink()
-    except OSError:
-        pass
+    # v2.2.2 #4: a unique id per launch so overlapping detached invocations for
+    # the same request can't cross-talk on a shared marker. The child inherits it
+    # via env and writes a run-scoped state file + log; the parent only ever polls
+    # THIS run's marker (no stale-marker unlink needed — the path is unique).
+    gate_run_id = os.urandom(5).hex()
+    log_path = out_dir / f"stage2_gate_{gate_run_id}.log"
+    state_path = out_dir / f"stage2_gate_state_{gate_run_id}.json"
+    child_env = dict(os.environ, U1_GATE_RUN_ID=gate_run_id)
     logf = open(log_path, "w")
     proc = subprocess.Popen(
         [sys.executable, gate_py] + argv,
-        stdout=logf, stderr=subprocess.STDOUT, start_new_session=True)
+        stdout=logf, stderr=subprocess.STDOUT, start_new_session=True, env=child_env)
 
     def _finish(stalled=False):
         logf.close()

--- a/scripts/u1_kit_workflow.py
+++ b/scripts/u1_kit_workflow.py
@@ -2290,10 +2290,22 @@ def run_kit_workflow(args) -> dict[str, Any]:
         # the phase: the looping re-form reset phase to awaiting_form while the
         # pending_bed_clear_start (nonce + confirm token) survived in safety
         # (confirmed on the live 2026-07-06 request).
-        _idem_safety = (u1_request.read_request(request_id) or {}).get("safety") or {}
+        _idem_req = u1_request.read_request(request_id) or {}
+        _idem_safety = _idem_req.get("safety") or {}
         _idem_pending = _idem_safety.get("pending_bed_clear_start") or {}
         _idem_tok = _idem_pending.get("confirm_token")
-        if _idem_pending.get("nonce") and _idem_tok:
+        # Fire ONLY for a genuine DUPLICATE redeem — the current form's answers
+        # are already consumed. A FIRST redeem still has its answers file and must
+        # proceed normally (slice + overwrite any stale pending); otherwise a
+        # request carrying a stale pending from a PRIOR run (request ids are
+        # content-derived, so re-uploads reuse the request) would wrongly
+        # re-surface the OLD plate instead of slicing the fresh answers.
+        _idem_fid = _idem_req.get("form_id")
+        try:
+            _answers_gone = not (_idem_fid and u1_form._answers_path(_idem_fid).exists())
+        except Exception:
+            _answers_gone = True
+        if _idem_pending.get("nonce") and _idem_tok and _answers_gone:
             _idem_prompt = (
                 "You already submitted this plate — it's sliced, uploaded, and "
                 "waiting on your bed-clear yes. Reply YES to start now, or NO to "

--- a/scripts/u1_print_start_gate.py
+++ b/scripts/u1_print_start_gate.py
@@ -402,7 +402,14 @@ def _write_approval_token(out_dir: Path, snapshot: dict[str, Any]) -> str:
 
 
 def _gate_state_path(out_dir) -> Path:
-    return Path(out_dir) / 'stage2_gate_state.json'
+    # v2.2.2 #4: run-scoped marker so overlapping detached invocations for one
+    # request never cross-talk. The parent passes a unique id via U1_GATE_RUN_ID
+    # and polls this exact path. Falls back to the shared name if unset (direct
+    # CLI use).
+    import os
+    run_id = os.environ.get('U1_GATE_RUN_ID', '')
+    name = f'stage2_gate_state_{run_id}.json' if run_id else 'stage2_gate_state.json'
+    return Path(out_dir) / name
 
 
 def _write_gate_state(out_dir, state: str, **extra) -> None:
@@ -413,10 +420,13 @@ def _write_gate_state(out_dir, state: str, **extra) -> None:
     being alive after 25s, which reported a stall as a healthy grace window.
     Best-effort: a marker write never blocks the gate."""
     try:
+        import os
         p = _gate_state_path(out_dir)
         p.parent.mkdir(parents=True, exist_ok=True)
         tmp = p.with_name(p.name + '.tmp')
-        tmp.write_text(json.dumps({'state': state, **extra}))
+        payload = {'state': state,
+                   'gate_run_id': os.environ.get('U1_GATE_RUN_ID', ''), **extra}
+        tmp.write_text(json.dumps(payload))
         tmp.replace(p)  # atomic
     except Exception:
         pass
@@ -444,18 +454,19 @@ def _consume_stage2_nonce(request_id: str, expected_nonce: str) -> bool:
                 fresh_safety.pop(k, None)
             u1_request.write_request(request_id, safety=fresh_safety)
             return True
-    except Exception:
-        # Locking unavailable (non-Unix / fs quirk): best-effort consume. The
-        # confirm-token atomic claim already serialises the realistic triggers.
+    except Exception as exc:
+        # Fail CLOSED (v2.2.2): if we cannot prove the nonce was valid AND
+        # durably consumed under the lock, REFUSE the start. Authorizing on a
+        # lock/read/write error (or a missing fcntl) is exactly backwards for a
+        # safety gate — the old best-effort fallback turned any such failure into
+        # an authorization. The target runtime is Linux, where fcntl is always
+        # present, so no permissive path is needed.
         try:
-            fresh_safety = dict((u1_request.read_request(request_id) or {}).get('safety') or {})
-            for k in ('stage2_approval_nonce', 'stage2_approval_issued_at',
-                      'stage2_approval_binds'):
-                fresh_safety.pop(k, None)
-            u1_request.write_request(request_id, safety=fresh_safety)
+            _audit_gate(request_id, 'stage2_nonce_consume_failed', 'gate',
+                        error=f"{type(exc).__name__}: {exc}"[:200])
         except Exception:
             pass
-        return True
+        return False
 
 
 def _approval_token_valid(stored: dict[str, Any], offered: str) -> tuple[bool, str]:
@@ -882,7 +893,14 @@ def run_gate(filename: str,
     # subprocess start can never reach this branch with the override honored.
     # The hardware safety isn't bypassed even then — just the mismatch refusal.
     overrides_used: list[dict[str, Any]] = []
-    _override_ok = bool(accept_material_mismatch and operator_text)
+    # v2.2.2: enforce the interactive-terminal requirement HERE, where the
+    # override is actually applied, not only in main(). A direct caller of
+    # run_gate() (bypassing the CLI) therefore cannot honor the override without
+    # an interactive TTY either. (A pty can still spoof isatty; that is treated
+    # as UX friction, not authentication — a single-operator homelab tool does
+    # not add a sudo/second-user ceremony for it.)
+    _tty_ok = bool(sys.stdin is not None and sys.stdin.isatty())
+    _override_ok = bool(accept_material_mismatch and operator_text and _tty_ok)
     if _override_ok:
         kept: list[str] = []
         for line in blockers:
@@ -903,10 +921,11 @@ def run_gate(filename: str,
                         expected_tool=intended_tool,
                         expected_material=requested_material,
                         blocker_text=overrides_used[0].get("blocker_text"))
-    elif accept_material_mismatch and not operator_text:
-        # Override requested with no operator authorization: refuse. Un-tag the
-        # [OVERRIDE:...] marker back to a clean hard blocker so the refusal reads
-        # normally, and audit the rejected attempt for forensics.
+    elif accept_material_mismatch and not _override_ok:
+        # Override requested but not authorized (missing operator text, or not
+        # from an interactive terminal): refuse. Un-tag the [OVERRIDE:...] marker
+        # back to a clean hard blocker so the refusal reads normally, and audit
+        # the rejected attempt for forensics.
         blockers = [
             (l[len("[OVERRIDE:material_mismatch] "):]
              if l.startswith("[OVERRIDE:material_mismatch] ") else l)
@@ -915,7 +934,8 @@ def run_gate(filename: str,
         if request_id:
             _audit_gate(request_id, "operator_override_rejected", resolved_operator,
                         override_kind="material_mismatch",
-                        reason="override_missing_operator_text",
+                        reason=("override_missing_operator_text" if not operator_text
+                                else "override_requires_interactive_terminal"),
                         expected_tool=intended_tool,
                         expected_material=requested_material)
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -122,6 +122,27 @@ def test_tg_single_select_in_group_does_not_advance_but_ungrouped_does():
     assert form["current"] == tg.REVIEW_FIELD
 
 
+def test_tg_edit_from_review_returns_to_review():
+    """Trap fix (live 2026-07-06): editing a field FROM the Review screen and
+    then advancing must return to Review, not march the operator forward through
+    the remaining screens (or dead-end). Going back to re-edit the head used to
+    trap the operator with no way to confirm."""
+    schema = _schema()
+    form = tg.new_form(schema)
+    form["current"] = tg.REVIEW_FIELD  # finished the form
+    # edit a GROUPED field (tool, in the setup group)
+    tg.apply_callback(form, "e:%d" % _fi(schema, "tool"))
+    assert form["current"] == "tool" and form.get("_edit_return")
+    # the group's shared Next must return to Review, NOT advance to 'profile'
+    tg.apply_callback(form, "n:%d" % _fi(schema, "tool"))
+    assert form["current"] == tg.REVIEW_FIELD
+    assert not form.get("_edit_return")  # flag cleared
+    # and an UNGROUPED field (profile): edit + tap also returns to Review
+    tg.apply_callback(form, "e:%d" % _fi(schema, "profile"))
+    tg.apply_callback(form, "s:%d:0" % _fi(schema, "profile"))
+    assert form["current"] == tg.REVIEW_FIELD
+
+
 def test_tg_all_and_none_shortcuts():
     form = tg.new_form(_schema(n_parts=4))
     tg.apply_callback(form, "a:0")  # All

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -49,3 +49,22 @@ def test_stage2_nonce_single_consume_under_concurrency():
         results = _race(lambda: g._consume_stage2_nonce(rid, nonce))
         winners = [r for r in results if r is True]
         assert len(winners) == 1, f"expected exactly one nonce consumer, got {sum(1 for r in results if r)}"
+
+
+def test_form_answers_single_redeem_under_concurrency():
+    """v2.2.2 #5: the form-answer file is CLAIMED (renamed) before it is read, so
+    concurrent redeems (double delivery / retry) cannot both process it. Exactly
+    one caller gets the answers; the rest see it already consumed."""
+    for _ in range(25):
+        fid = u1_form.new_form_id()
+        u1_form.write_answers_file(fid, {"tool": "T0", "material": "PLA"})
+
+        def _redeem():
+            try:
+                return u1_form.read_and_consume_answers(fid)
+            except FileNotFoundError:
+                return None
+
+        results = _race(_redeem)
+        winners = [r for r in results if isinstance(r, dict)]
+        assert len(winners) == 1, f"expected exactly one answer redeemer, got {len(winners)}"

--- a/tests/test_detached_gate.py
+++ b/tests/test_detached_gate.py
@@ -28,11 +28,14 @@ def test_fast_exit_returns_result(tmp_path):
 
 
 def test_grace_marker_returns_none(tmp_path):
-    """Child writes a grace_started marker: the window genuinely opened -> None."""
+    """Child writes a grace_started marker: the window genuinely opened -> None.
+    v2.2.2 #4: the marker is run-scoped; the child reads its id from U1_GATE_RUN_ID
+    (injected by the parent) and the parent polls that exact path."""
     gate = _fake_gate(tmp_path,
-        "import json,sys,time,pathlib\n"
+        "import json,sys,time,pathlib,os\n"
         "d=pathlib.Path(sys.argv[1])\n"
-        "(d/'stage2_gate_state.json').write_text(json.dumps({'state':'grace_started'}))\n"
+        "rid=os.environ.get('U1_GATE_RUN_ID','')\n"
+        "(d/f'stage2_gate_state_{rid}.json').write_text(json.dumps({'state':'grace_started'}))\n"
         "time.sleep(2)\n")
     res = kw._invoke_stage2_gate(gate, [str(tmp_path)], tmp_path)
     assert res is None

--- a/tests/test_u1_form_handoff.py
+++ b/tests/test_u1_form_handoff.py
@@ -198,6 +198,32 @@ def test_replayed_redemption_is_refused(tmp_path, hermetic_commit, capsys):
     assert any("redeem" in e for e in res2["errors"])
 
 
+def test_duplicate_redeem_reemits_bed_clear_not_form(tmp_path, hermetic_commit, capsys):
+    """v2.2.2: a SECOND --redeem-pending-form on a request that already sliced +
+    uploaded (a pending_bed_clear_start survives in safety) must re-surface the
+    SAME bed-clear prompt with the SAME confirm token, NOT render a fresh form. A
+    small model relaying the redeem twice stranded the operator in a form loop
+    (live 2026-07-06): the phase had been reset to awaiting_form but the pending
+    object survived, so the guard keys off that."""
+    zp = _kit_zip(tmp_path)
+    r1 = kw.run_kit_workflow(_args(zp, interaction_mode="form"))
+    rid = r1["request_id"]
+    tok = u1_form.new_confirm_token()
+    safety = dict((u1_request.read_request(rid) or {}).get("safety") or {})
+    safety["pending_bed_clear_start"] = {
+        "nonce": "n0", "confirm_token": tok, "prompt_key": "bed_clear_start"}
+    safety["snapshot_path"] = str(tmp_path / "bed.jpg")
+    u1_request.write_request(rid, safety=safety)
+    u1_form.persist_confirm_token(tok, rid)
+    capsys.readouterr()  # clear prior output
+    res = kw.run_kit_workflow(_args(zp, request_id=rid,
+                                    redeem_pending_form=True, live_upload=True))
+    assert res["phase"] == "awaiting_bed_clear_start", res
+    out = capsys.readouterr().out
+    assert "bed_clear_start" in out and tok in out   # same prompt + token re-surfaced
+    assert '"kit_form"' not in out                   # did NOT re-render a fresh form
+
+
 def test_mismatched_form_id_refused_and_file_preserved(tmp_path, hermetic_commit, capsys):
     zp = _kit_zip(tmp_path)
     r1 = kw.run_kit_workflow(_args(zp, interaction_mode="form"))

--- a/tests/test_u1_form_handoff.py
+++ b/tests/test_u1_form_handoff.py
@@ -224,6 +224,30 @@ def test_duplicate_redeem_reemits_bed_clear_not_form(tmp_path, hermetic_commit, 
     assert '"kit_form"' not in out                   # did NOT re-render a fresh form
 
 
+def test_fresh_redeem_ignores_stale_pending(tmp_path, hermetic_commit, capsys):
+    """v2.2.2: a FIRST redeem (its answers file present) must PROCEED and slice
+    the fresh answers even if a STALE pending_bed_clear_start from a prior run
+    lingers — request ids are content-derived, so re-uploading the same kit
+    reuses the request. The idempotency guard must fire ONLY when the answers are
+    gone (a genuine duplicate), never re-surfacing the old plate over fresh
+    answers."""
+    zp = _kit_zip(tmp_path)
+    r1 = kw.run_kit_workflow(_args(zp, interaction_mode="form"))
+    fid, rid = r1["form_id"], r1["request_id"]
+    # A stale pending from a "previous" run lingering in safety.
+    safety = dict((u1_request.read_request(rid) or {}).get("safety") or {})
+    safety["pending_bed_clear_start"] = {
+        "nonce": "stale", "confirm_token": u1_form.new_confirm_token()}
+    u1_request.write_request(rid, safety=safety)
+    # Fresh answers for THIS form are present.
+    u1_form.write_answers_file(fid, {
+        "parts": "all", "tool": "T0", "material": "PLA",
+        "profile": 1, "supports": "no-supports", "action": "upload-only"})
+    res = kw.run_kit_workflow(_args(zp, request_id=rid,
+                                    redeem_pending_form=True, live_upload=True))
+    assert res["phase"] == "complete", res  # proceeded; did NOT re-surface old plate
+
+
 def test_mismatched_form_id_refused_and_file_preserved(tmp_path, hermetic_commit, capsys):
     zp = _kit_zip(tmp_path)
     r1 = kw.run_kit_workflow(_args(zp, interaction_mode="form"))

--- a/tests/test_u1_kit_workflow.py
+++ b/tests/test_u1_kit_workflow.py
@@ -738,3 +738,21 @@ def test_plate_isometric_from_gcode_renders(tmp_path):
     plain = tmp_path / "plain.gcode"
     plain.write_text("G1 X10 Y10 E1\n")
     assert kw._render_plate_isometric_from_gcode(plain, tmp_path / "iso2.png")["ok"] is False
+
+
+def test_plate_isometric_keeps_duplicate_copies(tmp_path):
+    """v2.2.2 #3: two copies of the SAME model (same base name, distinct M486
+    instance ids) at different XY must BOTH render in the 3D view. Keying by the
+    stripped base name collapsed them into one part (the largest-loop pick) while
+    the top-down drew both, so the two review images disagreed. Geometry is now
+    keyed by instance."""
+    unit = [(0, 0), (40, 0), (40, 40), (0, 40)]
+    copy_a = [(20 + x, 20 + y) for (x, y) in unit]
+    copy_b = [(150 + x, 150 + y) for (x, y) in unit]  # a second copy, far away
+    gp = tmp_path / "plate.gcode"
+    # same base "widget" for both -> the helper still gives them distinct
+    # _id_<n>_copy_0 instance ids, i.e. two copies of one model.
+    _make_m486_gcode(gp, [("widget", copy_a), ("widget", copy_b)])
+    r = kw._render_plate_isometric_from_gcode(
+        gp, tmp_path / "iso_dup.png", bed_mm=(270, 270), title="Plate 1 of 1")
+    assert r["ok"] and r["part_count"] == 2  # both copies kept, not collapsed to 1

--- a/tests/test_u1_print_start_gate.py
+++ b/tests/test_u1_print_start_gate.py
@@ -1,4 +1,5 @@
 import hashlib
+import io
 import json
 from pathlib import Path
 
@@ -446,9 +447,16 @@ def test_run_gate_override_refused_without_operator_text(monkeypatch, tmp_path):
     assert res['started'] is False
 
 
+class _FakeTTY:
+    def isatty(self):
+        return True
+
+
 def test_run_gate_override_applies_with_operator_text(monkeypatch, tmp_path):
-    """With a genuine operator_text, the material override applies and the start
-    proceeds (the escape hatch still works for a real operator at the CLI)."""
+    """With a genuine operator_text AND an interactive terminal, the material
+    override applies and the start proceeds (the escape hatch still works for a
+    real operator at the CLI)."""
+    monkeypatch.setattr(g.sys, "stdin", _FakeTTY())  # v2.2.2: override needs a TTY
     rid, token = _seed_stage1_token(monkeypatch, tmp_path)
     res = g.run_gate('x.gcode', bed_clear='start', host='h', port=1,
                      intended_tool='extruder', requested_material='PETG',
@@ -457,3 +465,29 @@ def test_run_gate_override_applies_with_operator_text(monkeypatch, tmp_path):
                      operator_text='I accept PLA loaded at PETG temp',
                      out_dir=tmp_path, start_func=lambda *a: {'result': 'ok'})
     assert res['started'] is True
+
+
+def test_run_gate_override_refused_without_tty(monkeypatch, tmp_path):
+    """v2.2.2 #1: the override is enforced at the apply-point, not only in
+    main(). A direct run_gate() caller WITHOUT an interactive terminal (an
+    agent/subprocess) cannot honor the override even with operator_text — the
+    material mismatch still blocks the start."""
+    monkeypatch.setattr(g.sys, "stdin", io.StringIO())  # isatty() -> False
+    rid, token = _seed_stage1_token(monkeypatch, tmp_path)
+    res = g.run_gate('x.gcode', bed_clear='start', host='h', port=1,
+                     intended_tool='extruder', requested_material='PETG',
+                     approval_token=token, request_id=rid,
+                     accept_material_mismatch=True,
+                     operator_text='I accept PLA loaded at PETG temp',
+                     out_dir=tmp_path, start_func=lambda *a: {'result': 'ok'})
+    assert res['started'] is not True
+
+
+def test_consume_stage2_nonce_fails_closed_on_exception(monkeypatch, tmp_path):
+    """v2.2.2 #2: if consuming the Stage-2 nonce raises (lock/read/write failure,
+    missing fcntl), the gate must REFUSE (return False), never authorize. The old
+    best-effort fallback returned True on error, which is fail-open."""
+    def _boom(*a, **k):
+        raise OSError("simulated fs failure under the lock")
+    monkeypatch.setattr(u1_request, "ensure_request_dir", _boom)
+    assert g._consume_stage2_nonce("u1_2026_0101_abcdef", "some-nonce") is False


### PR DESCRIPTION
Safety hardening plus two operator-reported form UX bugs. Verified live on real hardware (gemma4-26b over Telegram): a full kit ran form -> slice -> previews -> bed-clear -> grace window -> operator cancel, with every fix engaged.

### Safety
- Stage-2 nonce consumption fails CLOSED: any lock/read/write failure refuses the start instead of authorizing it (the old best-effort fallback returned success on error).
- The material-mismatch override enforces its interactive-terminal requirement at the apply-point, not only in the CLI entrypoint.
- Each detached gate launch gets a unique run id (state marker + log), so overlapping invocations can't cross-talk.
- Form answers are claimed (atomic rename) before being read, so concurrent redeems can't both act on one submission.

### Fixed
- Duplicate copies of one model all render in the 3D plate view (geometry keyed by instance id; copies share a color).
- Re-editing a completed form no longer traps the operator: editing from Review returns to Review.
- A duplicated redeem command re-surfaces the bed-clear prompt instead of re-rendering a fresh form.

### Changed
- The snapmaker_u1 gateway plugin (attachment auto-skill + next-action directive) is now tracked in-repo under plugin/ (pip install -e ./plugin/). Previously an untracked local dir that could silently vanish and take the attachment-to-skill flow with it.

### Tests
710 pass, including fault-injection (nonce fail-closed), no-TTY override refusal, duplicate-copy render, concurrent redeem, and the form re-edit regression.