### PR TITLE
docs: finish the README pass past First slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,23 @@ the LED on to be useful, but leaving the cavity bright forever after a
 finished print is wasteful and surprising. The 5-minute grace gives you
 time to inspect the bed before it goes dark.
 
+## Profile sources
+
+Your profiles should be *yours*: extracted from your own successful prints,
+mapped to your own extruders. The toolkit ships with an empty `profiles/` dir on
+purpose and gives you three honest sources: Snapmaker's stock profiles,
+profiles extracted from prints that already succeeded on your printer, and
+your own hand-tuned files. The full guide (first-run setup, supports
+auto-detection, and building per-extruder profiles from print history) is in
+[docs/PROFILES.md](docs/PROFILES.md).
+
+## Headless slicing setup (no GUI / scripted)
+
+Slicing from the CLI in a container, CI pipeline, or agent workflow, with no
+OrcaSlicer GUI: which build to use, the 3-profile load order, a real
+inheritance pitfall and its workaround, and the orientation-review and
+thumbnail-injection tools. Full guide: [docs/HEADLESS.md](docs/HEADLESS.md).
+
 ## Optional: notify me when OrcaSlicer has an update
 
 The toolkit ships a small checker that compares your installed `orca-slicer` version against the upstream latest release. **It does nothing unless you wire it into your scheduler.** Cloning the repo does not subscribe you to anything.
@@ -471,178 +488,6 @@ Real reverse-engineering notes from getting these scripts working — the kind o
 | `references/snapmaker-u1-toolmap-script-2026-06.md` | Material-gate design rationale |
 | `references/snapmaker-u1-orca-moonraker.md` | OrcaSlicer + Moonraker integration |
 | `references/snapmaker-u1-research.md` | First-pass research summary |
-
-## Profile sources
-
-Your profiles should be *yours*: extracted from your own successful prints,
-mapped to your own extruders. The toolkit ships with an empty `profiles/` dir on
-purpose and gives you three honest sources: Snapmaker's stock profiles
-(`tools/fetch_snapmaker_profiles.py`), profiles extracted from prints that
-already succeeded on your printer, and your own hand-tuned files. The full
-guide (first-run setup, supports auto-detection, and building per-extruder
-profiles from print history) is in [docs/PROFILES.md](docs/PROFILES.md).
-
-## Headless slicing setup (no GUI / scripted)
-
-Use this if you're slicing from CLI in a container, CI pipeline, or agent workflow.
-
-### Use upstream OrcaSlicer, not the Snapmaker fork
-
-> **Important**: use **upstream [OrcaSlicer](https://github.com/OrcaSlicer/OrcaSlicer)
-> v2.4.0+**, not Snapmaker's fork. Snapmaker upstreamed the U1 vendor profile
-> into upstream OrcaSlicer 2.4.0, so it has full U1 support — and its CLI is
-> the better-supported headless path. The Snapmaker fork's Windows CLI has
-> been observed to segfault when slicing with these profiles (verified
-> `snapmaker-orca v2.3.4` Windows can exit code `-1073741819` on some models).
-
-### Install — Linux (extracted AppImage)
-
-```bash
-# Download upstream OrcaSlicer Linux AppImage
-wget https://github.com/OrcaSlicer/OrcaSlicer/releases/download/v2.4.0/OrcaSlicer_Linux_AppImage_Ubuntu2404_V2.4.0.AppImage \
-  -O ~/orcaslicer.AppImage
-chmod +x ~/orcaslicer.AppImage
-
-# Extract instead of mounting (containers without FUSE)
-mkdir -p ~/orcaslicer-install && cd ~/orcaslicer-install
-~/orcaslicer.AppImage --appimage-extract
-# Creates ./squashfs-root/
-
-# Some minimal distros are missing GUI/runtime libs Orca expects.
-# If you hit "libGL.so.1 not found" or similar:
-mkdir local-libs && cd local-libs
-apt-get download libgl1 libegl1 libxkbcommon0 libwayland-client0 libnss3 \
-                 libasound2 libgtk-3-0 libdbus-1-3 libsecret-1-0
-for d in *.deb; do dpkg-deb -x "$d" .; done
-```
-
-### Install — Windows (portable zip, no installer needed)
-
-```powershell
-# Download upstream OrcaSlicer Windows portable
-Invoke-WebRequest -Uri https://github.com/OrcaSlicer/OrcaSlicer/releases/download/v2.4.0/OrcaSlicer_Windows_V2.4.0_portable.zip `
-    -OutFile $env:TEMP\OrcaSlicer.zip
-Expand-Archive $env:TEMP\OrcaSlicer.zip -DestinationPath $env:TEMP\orca240
-
-# The CLI binary lives at $env:TEMP\orca240\orca-slicer.exe
-```
-
-### Slice a single STL — the 3-profile chain
-
-Headless slicing needs **three** profiles in a specific load order:
-
-1. **Machine** — the printer definition (this repo bundles a flattened standalone copy)
-2. **Process** — layer height, walls, infill, supports
-3. **Filament** — material, temps, retraction
-
-> **Pass each profile via its own `--load-settings` flag** (not one flag with
-> semicolon-separated paths). Both forms are documented in OrcaSlicer, but
-> the dual-flag form is the one verified-working in our test runs (Hermes
-> Windows) and avoids quoting foot-guns on PowerShell.
-
-```bash
-# Linux
-ORCA=$HOME/orcaslicer-install
-PROFILES=$(pwd)/profiles
-
-LD_LIBRARY_PATH="$ORCA/local-libs/usr/lib/x86_64-linux-gnu:$ORCA/squashfs-root/usr/lib:$ORCA/squashfs-root/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH" \
-  $ORCA/squashfs-root/bin/orca-slicer \
-  --load-settings "$PROFILES/machine/snapmaker_u1_0_4_nozzle.json" \
-  --load-settings "$PROFILES/community_merged_016_optimal_u1_textured_pei.json" \
-  --load-filaments "$PROFILES/community_generic_petg_u1_textured_pei.json" \
-  --outputdir ./output \
-  --slice 0 \
-  my_model.stl
-```
-
-```powershell
-# Windows (PowerShell)
-& "$env:TEMP\orca240\orca-slicer.exe" `
-  --load-settings "profiles\machine\snapmaker_u1_0_4_nozzle.json" `
-  --load-settings "profiles\community_merged_016_optimal_u1_textured_pei.json" `
-  --load-filaments "profiles\community_generic_petg_u1_textured_pei.json" `
-  --outputdir .\output `
-  --slice 0 `
-  my_model.stl
-```
-
-Sliced G-code lands in `./output/plate_1.gcode`.
-
-> **Why the bundled machine profile?** Upstream Orca's bundled U1 profile
-> inherits from `fdm_U1` → `fdm_toolchanger` → `fdm_klipper`. Loading the
-> bundled vendor copy via CLI requires Orca to find every parent in its
-> install resources, which is fragile across platforms. The repo's
-> `profiles/machine/snapmaker_u1_0_4_nozzle.json` is **fully flattened**
-> — every inherited field merged into one standalone file. Headless CLI
-> sees one file, gets the complete machine definition, no resolution
-> magic needed. Derived from upstream OrcaSlicer's `Snapmaker/machine/`
-> vendor profiles (AGPL-3.0, contributed by Snapmaker).
-
-### Headless profile-loading pitfall (READ THIS)
-
-OrcaSlicer's bundled Snapmaker process profiles **do not always resolve inheritance correctly via CLI**. Symptoms seen in testing:
-
-- `filament_settings_id` says PETG but `filament_type` becomes PLA → wrong temps
-- Layer-height preset of 0.16 produces G-code with `layer_height = 0.2`
-- Bed/nozzle temps default to PLA-safe values regardless of selected filament
-
-**Workaround**: use profiles whose inheritance chain CLI can resolve. Three good options today:
-
-- `tools/extract_profiles_from_printer.py` writes **flat process JSONs from your successful prints** (no inheritance) — physics-validated AND CLI-safe by construction. Best default.
-- `tools/fetch_snapmaker_profiles.py` pulls Snapmaker's upstream stock — CLI resolves these against the bundled OrcaSlicer install when the install matches the stock branch.
-- `examples/profiles/community_merged_*` (in `examples/`) is the legacy flat-profile shape; if you're handwriting your own, follow that pattern. The `_override` variants only work in the GUI where Orca resolves the official base profile. The same flatness logic applies to the bundled machine profile above.
-
-### Pre-print orientation review
-
-Before you slice, ask the question every operator forgets: *is this the right
-orientation, and where will it need supports?* The orientation renderer
-gives you a 4-panel image showing isometric / front / side / top views with
-all downward-facing triangles highlighted in orange — those are the faces a
-slicer will warn about.
-
-```bash
-pip install Pillow numpy  # one-time (same deps as the thumbnail tool)
-
-python3 tools/render_stl_orientation.py model.stl \
-    --out orientation.png \
-    --title "Orbital sander vacuum attachment"
-```
-
-Output is a single PNG with header text (bounding-box dims, Z range, count
-of overhang triangles) and the 4 views. Tunable via `--overhang-threshold`
-if your slicer/material is more or less paranoid than the default (-0.3 ≈
-17° below horizontal).
-
-### Add a Snapmaker-app preview thumbnail
-
-OrcaSlicer's CLI path doesn't render thumbnails (GUI-only — verified with `--debug 5`, no GL/xvfb workaround helps). Without them, the Snapmaker app shows a generic icon for every print. Use the included tool to splice PrusaSlicer/Orca-format thumbnail blocks into the G-code post-slice:
-
-```bash
-pip install Pillow numpy  # one-time
-
-python3 tools/gcode_inject_thumbnail.py \
-    --stl my_model.stl --gcode output/plate_1.gcode \
-    --sizes 48x48,300x300 --in-place
-```
-
-Runs an isometric projection of the STL through PIL (Lambertian-shaded triangles, painter's algorithm), base64-encodes the PNGs, and splices `; thumbnail begin … ; thumbnail end` blocks into the G-code header. Idempotent — re-running replaces existing blocks, not stacks them. Moonraker + Snapmaker app parse them as standard previews.
-
-### Validate G-code before upload
-
-```bash
-grep -E '^; (filament_type|layer_height|first_layer_temperature|bed_temperature) ' output/plate_1.gcode
-```
-
-Expected output for the merged 0.16 Optimal PETG profile:
-
-```
-; filament_type = PETG
-; layer_height = 0.16
-; first_layer_temperature = 255
-; bed_temperature = 80
-```
-
-If any of those are wrong, the CLI didn't load your profiles correctly — fix before uploading.
 
 ## Running the tests
 

--- a/docs/HEADLESS.md
+++ b/docs/HEADLESS.md
@@ -1,0 +1,173 @@
+# Headless OrcaSlicer setup
+
+How to slice from the CLI with no GUI (containers, CI pipelines, agent workflows): which OrcaSlicer build to use, the 3-profile load order, a real inheritance pitfall and its workaround, plus the orientation-review and thumbnail-injection tools.
+
+[← Back to the README](../README.md)
+
+---
+
+## Headless slicing setup (no GUI / scripted)
+
+Use this if you're slicing from CLI in a container, CI pipeline, or agent workflow.
+
+### Use upstream OrcaSlicer, not the Snapmaker fork
+
+> **Important**: use **upstream [OrcaSlicer](https://github.com/OrcaSlicer/OrcaSlicer)
+> v2.4.0+**, not Snapmaker's fork. Snapmaker upstreamed the U1 vendor profile
+> into upstream OrcaSlicer 2.4.0, so it has full U1 support — and its CLI is
+> the better-supported headless path. The Snapmaker fork's Windows CLI has
+> been observed to segfault when slicing with these profiles (verified
+> `snapmaker-orca v2.3.4` Windows can exit code `-1073741819` on some models).
+
+### Install — Linux (extracted AppImage)
+
+```bash
+# Download upstream OrcaSlicer Linux AppImage
+wget https://github.com/OrcaSlicer/OrcaSlicer/releases/download/v2.4.0/OrcaSlicer_Linux_AppImage_Ubuntu2404_V2.4.0.AppImage \
+  -O ~/orcaslicer.AppImage
+chmod +x ~/orcaslicer.AppImage
+
+# Extract instead of mounting (containers without FUSE)
+mkdir -p ~/orcaslicer-install && cd ~/orcaslicer-install
+~/orcaslicer.AppImage --appimage-extract
+# Creates ./squashfs-root/
+
+# Some minimal distros are missing GUI/runtime libs Orca expects.
+# If you hit "libGL.so.1 not found" or similar:
+mkdir local-libs && cd local-libs
+apt-get download libgl1 libegl1 libxkbcommon0 libwayland-client0 libnss3 \
+                 libasound2 libgtk-3-0 libdbus-1-3 libsecret-1-0
+for d in *.deb; do dpkg-deb -x "$d" .; done
+```
+
+### Install — Windows (portable zip, no installer needed)
+
+```powershell
+# Download upstream OrcaSlicer Windows portable
+Invoke-WebRequest -Uri https://github.com/OrcaSlicer/OrcaSlicer/releases/download/v2.4.0/OrcaSlicer_Windows_V2.4.0_portable.zip `
+    -OutFile $env:TEMP\OrcaSlicer.zip
+Expand-Archive $env:TEMP\OrcaSlicer.zip -DestinationPath $env:TEMP\orca240
+
+# The CLI binary lives at $env:TEMP\orca240\orca-slicer.exe
+```
+
+### Slice a single STL — the 3-profile chain
+
+Headless slicing needs **three** profiles in a specific load order:
+
+1. **Machine** — the printer definition (this repo bundles a flattened standalone copy)
+2. **Process** — layer height, walls, infill, supports
+3. **Filament** — material, temps, retraction
+
+> **Pass each profile via its own `--load-settings` flag** (not one flag with
+> semicolon-separated paths). Both forms are documented in OrcaSlicer, but
+> the dual-flag form is the one verified-working in our test runs (Hermes
+> Windows) and avoids quoting foot-guns on PowerShell.
+
+```bash
+# Linux
+ORCA=$HOME/orcaslicer-install
+PROFILES=$(pwd)/profiles
+
+LD_LIBRARY_PATH="$ORCA/local-libs/usr/lib/x86_64-linux-gnu:$ORCA/squashfs-root/usr/lib:$ORCA/squashfs-root/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH" \
+  $ORCA/squashfs-root/bin/orca-slicer \
+  --load-settings "$PROFILES/machine/snapmaker_u1_0_4_nozzle.json" \
+  --load-settings "$PROFILES/community_merged_016_optimal_u1_textured_pei.json" \
+  --load-filaments "$PROFILES/community_generic_petg_u1_textured_pei.json" \
+  --outputdir ./output \
+  --slice 0 \
+  my_model.stl
+```
+
+```powershell
+# Windows (PowerShell)
+& "$env:TEMP\orca240\orca-slicer.exe" `
+  --load-settings "profiles\machine\snapmaker_u1_0_4_nozzle.json" `
+  --load-settings "profiles\community_merged_016_optimal_u1_textured_pei.json" `
+  --load-filaments "profiles\community_generic_petg_u1_textured_pei.json" `
+  --outputdir .\output `
+  --slice 0 `
+  my_model.stl
+```
+
+Sliced G-code lands in `./output/plate_1.gcode`.
+
+> **Why the bundled machine profile?** Upstream Orca's bundled U1 profile
+> inherits from `fdm_U1` → `fdm_toolchanger` → `fdm_klipper`. Loading the
+> bundled vendor copy via CLI requires Orca to find every parent in its
+> install resources, which is fragile across platforms. The repo's
+> `profiles/machine/snapmaker_u1_0_4_nozzle.json` is **fully flattened**
+> — every inherited field merged into one standalone file. Headless CLI
+> sees one file, gets the complete machine definition, no resolution
+> magic needed. Derived from upstream OrcaSlicer's `Snapmaker/machine/`
+> vendor profiles (AGPL-3.0, contributed by Snapmaker).
+
+### Headless profile-loading pitfall (READ THIS)
+
+OrcaSlicer's bundled Snapmaker process profiles **do not always resolve inheritance correctly via CLI**. Symptoms seen in testing:
+
+- `filament_settings_id` says PETG but `filament_type` becomes PLA → wrong temps
+- Layer-height preset of 0.16 produces G-code with `layer_height = 0.2`
+- Bed/nozzle temps default to PLA-safe values regardless of selected filament
+
+**Workaround**: use profiles whose inheritance chain CLI can resolve. Three good options today:
+
+- `tools/extract_profiles_from_printer.py` writes **flat process JSONs from your successful prints** (no inheritance) — physics-validated AND CLI-safe by construction. Best default.
+- `tools/fetch_snapmaker_profiles.py` pulls Snapmaker's upstream stock — CLI resolves these against the bundled OrcaSlicer install when the install matches the stock branch.
+- `examples/profiles/community_merged_*` (in `examples/`) is the legacy flat-profile shape; if you're handwriting your own, follow that pattern. The `_override` variants only work in the GUI where Orca resolves the official base profile. The same flatness logic applies to the bundled machine profile above.
+
+### Pre-print orientation review
+
+Before you slice, ask the question every operator forgets: *is this the right
+orientation, and where will it need supports?* The orientation renderer
+gives you a 4-panel image showing isometric / front / side / top views with
+all downward-facing triangles highlighted in orange — those are the faces a
+slicer will warn about.
+
+```bash
+pip install Pillow numpy  # one-time (same deps as the thumbnail tool)
+
+python3 tools/render_stl_orientation.py model.stl \
+    --out orientation.png \
+    --title "Orbital sander vacuum attachment"
+```
+
+Output is a single PNG with header text (bounding-box dims, Z range, count
+of overhang triangles) and the 4 views. Tunable via `--overhang-threshold`
+if your slicer/material is more or less paranoid than the default (-0.3 ≈
+17° below horizontal).
+
+### Add a Snapmaker-app preview thumbnail
+
+OrcaSlicer's CLI path doesn't render thumbnails (GUI-only — verified with `--debug 5`, no GL/xvfb workaround helps). Without them, the Snapmaker app shows a generic icon for every print. Use the included tool to splice PrusaSlicer/Orca-format thumbnail blocks into the G-code post-slice:
+
+```bash
+pip install Pillow numpy  # one-time
+
+python3 tools/gcode_inject_thumbnail.py \
+    --stl my_model.stl --gcode output/plate_1.gcode \
+    --sizes 48x48,300x300 --in-place
+```
+
+Runs an isometric projection of the STL through PIL (Lambertian-shaded triangles, painter's algorithm), base64-encodes the PNGs, and splices `; thumbnail begin … ; thumbnail end` blocks into the G-code header. Idempotent — re-running replaces existing blocks, not stacks them. Moonraker + Snapmaker app parse them as standard previews.
+
+### Validate G-code before upload
+
+```bash
+grep -E '^; (filament_type|layer_height|first_layer_temperature|bed_temperature) ' output/plate_1.gcode
+```
+
+Expected output for the merged 0.16 Optimal PETG profile:
+
+```
+; filament_type = PETG
+; layer_height = 0.16
+; first_layer_temperature = 255
+; bed_temperature = 80
+```
+
+If any of those are wrong, the CLI didn't load your profiles correctly — fix before uploading.
+
+---
+
+[← Back to the README](../README.md)


### PR DESCRIPTION
PR #9 got merged before I finished the back half of the pass, so this commit landed on the same branch after the PR closed and never got its own PR. Here it is properly.

Finishes the restructure past "First slice": fetch_snapmaker_profiles.py and extract_profiles_from_printer.py were explained five separate times, and the 160-line Headless slicing section restated the same profile philosophy Profile sources had just covered one paragraph above it.

- Headless slicing setup moved to docs/HEADLESS.md (same pattern as PROFILES.md/SAFETY.md), one paragraph + link left in the README.
- Profile-tool mentions down to 3, all legitimate: the real install command, one script-table row, one unrelated compatibility fact.
- Reordered the reference cluster after Hermes integration into one sequence: scripts table -> Configuration -> Profile sources -> Headless (link) -> optional update notifier -> reverse-engineering docs -> tests/validation/limitations/license.

711 -> 556 lines. No anchors broken, no content lost.