### PR TITLE
v2.3.1: safety hardening (fail-open decisions + audit fixes)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/adapters/hermes/plugin/telegram_patch.py
+++ b/adapters/hermes/plugin/telegram_patch.py
@@ -277,6 +277,7 @@ def ensure_patched(adapter_cls) -> bool:
             "form": form, "schema": form_schema,
             "session_key": session_key, "msg_id": msg.message_id,
             "chat_id": int(chat_id),
+            "last_text": screen["text"],
         }
         return _make_send_result(success=True, message_id=str(msg.message_id))
 
@@ -354,10 +355,23 @@ def ensure_patched(adapter_cls) -> bool:
         text = screen["text"] + (f"\n\n⚠ {warning}" if warning else "")
         try:
             from telegram.constants import ParseMode  # type: ignore
-            await q.edit_message_text(text, parse_mode=ParseMode.HTML,
-                                      reply_markup=_rows_to_markup(screen["keyboard"]))
+            markup = _rows_to_markup(screen["keyboard"])
+            if text == slot.get("last_text"):
+                # Only the SELECTION changed, not the screen text (a radio/
+                # multi tap within the current screen). Edit JUST the keyboard
+                # — a full edit_message_text re-sends all the HTML text too,
+                # which Telegram throttles on rapid taps and makes the
+                # selection dot visibly lag behind the tap. Keyboard-only
+                # edits are a fraction of the payload and snap immediately.
+                await q.edit_message_reply_markup(reply_markup=markup)
+            else:
+                await q.edit_message_text(text, parse_mode=ParseMode.HTML,
+                                          reply_markup=markup)
+                slot["last_text"] = text
         except Exception as exc:
-            logger.warning("u1-form: rerender edit failed: %s", exc)
+            # "message is not modified" (identical tap) is benign; others log.
+            if "not modified" not in str(exc).lower():
+                logger.warning("u1-form: rerender edit failed: %s", exc)
 
     # NOTE deliberately NOT touching adapter_cls._handle_callback_query —
     # PTB holds the bound method it captured at connect(); replacing the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "real_gcode_exists: exercise the real gcode_exists_on_printer (skip the file-exists stub)",
+]
 pythonpath = ["scripts"]

--- a/scripts/u1_kit_workflow.py
+++ b/scripts/u1_kit_workflow.py
@@ -2130,7 +2130,7 @@ def run_kit_workflow(args) -> dict[str, Any]:
         # Child-ack commitment point: we have a token and are about to consume
         # it. Release our claim now — a crash before here is recoverable by
         # the hook reaper; a crash after here spent the token either way.
-        _release_confirm_claim(_confirm_for)
+        _release_confirm_claim(_confirm_for, getattr(args, "confirm_claim_id", None))
     if _confirm_token:
         _rid = u1_form.resolve_confirm_token(_confirm_token)  # consumes it
         _state = u1_request.read_request(_rid) if _rid else None
@@ -3552,13 +3552,25 @@ def _spawn_confirm_expiry_watchdog(request_id: str,
         pass
 
 
-def _release_confirm_claim(request_id: str) -> None:
-    """Child-ack (Q3, 2026-07-08): remove the confirm hook's claim marker(s)
-    for this request. Called by the confirmed turn RIGHT BEFORE it consumes
-    the single-use token — the point of commitment. A child that crashes
-    before here leaves the claim for the hook's reaper to restore, so the
-    operator's YES is not spent by a child that never redeemed it."""
+def _release_confirm_claim(request_id: str, claim_id: str | None = None) -> None:
+    """Child-ack (Q3, 2026-07-08; scoped by claim_id in audit 2026-07-09):
+    remove THIS spawn's claim marker right before the single-use token is
+    consumed — the point of commitment. A child that crashes before here leaves
+    the claim for the hook's reaper to restore, so the operator's YES is not
+    spent by a child that never redeemed it.
+
+    With a claim_id (the normal hook path) we unlink ONLY
+    <rid>.claimed.<claim_id>.json — deleting every claim for the request could
+    strand a concurrently re-armed generation whose own child hasn't committed
+    yet (audit finding #3). Without one (direct/legacy invocation) fall back to
+    the request-wide glob."""
     try:
+        if claim_id:
+            try:
+                (_PENDING_CONFIRM_DIR / f"{request_id}.claimed.{claim_id}.json").unlink()
+            except FileNotFoundError:
+                pass
+            return
         for c in _PENDING_CONFIRM_DIR.glob(f"{request_id}.claimed.*.json"):
             try:
                 c.unlink()
@@ -5466,6 +5478,12 @@ def main(argv=None) -> int:
                           "for the u1_confirm_start hook, which builds this "
                           "command from its own constants — the pending "
                           "marker carries no command and no token."))
+    ap.add_argument("--confirm-claim-id", default=None, dest="confirm_claim_id",
+                    help=("Q3 (audit 2026-07-09): the exact claim id the confirm "
+                          "hook created for THIS spawn. At the commitment point "
+                          "the child releases ONLY its own "
+                          "<rid>.claimed.<id>.json, so a concurrently re-armed "
+                          "generation's claim is never deleted. Hook-set only."))
     ap.add_argument("--grace-cancel", action="store_true", dest="grace_cancel",
                     help=("Cancel every active pre-start grace window (touches "
                           "the same markers the gateway cancel hook does). The "

--- a/scripts/u1_kit_workflow.py
+++ b/scripts/u1_kit_workflow.py
@@ -2151,19 +2151,19 @@ def run_kit_workflow(args) -> dict[str, Any]:
         _disarm_pending_confirm(_rid)
         _audit(_rid, "bed_clear_confirm_token_redeemed", operator,
                token_first6=str(_confirm_token)[:6])
-        if _state.get("reprint_of"):
-            # Reprint confirm (v2.3): there is NO archive to re-ingest — the
-            # gcode is already in printer storage and everything the confirmed
-            # turn validates (pending nonce, revision, plate hash, tool,
-            # material) is persisted on the request. Falling through would hit
-            # the model-positional recovery and die on the original upload's
-            # long-gone cache file (live 2026-07-06: the operator's YES
-            # errored, stranding the reprint at the finish line). Route
-            # straight to the gate turn.
-            return _action_start(None, _rid,
-                                 bool(getattr(args, "json_events", False)),
-                                 bed_clear_confirmed=True, operator=operator,
-                                 pending_nonce=_pending.get("nonce"))
+        # EVERY confirmed start routes straight to the gate turn — never
+        # re-ingest the archive. The confirmed turn only validates state
+        # already persisted on the request (pending nonce, revision, gcode
+        # hash, tool, material, approval token); re-ingesting is unnecessary
+        # AND fragile. Two live failures proved it: a reprint's confirm died
+        # on the long-gone upload cache (2026-07-06), and a normal kit's
+        # confirm re-analyzed parts and returned 'awaiting_parts' after a
+        # duplicate mid-flow re-run left kit.selected unset (2026-07-08). The
+        # reprint special-case is now the universal rule.
+        return _action_start(None, _rid,
+                             bool(getattr(args, "json_events", False)),
+                             bed_clear_confirmed=True, operator=operator,
+                             pending_nonce=_pending.get("nonce"))
     # ── REPRINT (v2.3): both turns work with NO model positional ──
     # Turn 1 (--reprint): list recent prints, one single-use pick token each.
     # Turn 2 (--reprint-start <token>): seed a fresh request from the picked

--- a/scripts/u1_kit_workflow.py
+++ b/scripts/u1_kit_workflow.py
@@ -2127,6 +2127,10 @@ def run_kit_workflow(args) -> dict[str, Any]:
             }), flush=True)
             return {"phase": "bed_clear_confirm_no_pending",
                     "request_id": _confirm_for}
+        # Child-ack commitment point: we have a token and are about to consume
+        # it. Release our claim now — a crash before here is recoverable by
+        # the hook reaper; a crash after here spent the token either way.
+        _release_confirm_claim(_confirm_for)
     if _confirm_token:
         _rid = u1_form.resolve_confirm_token(_confirm_token)  # consumes it
         _state = u1_request.read_request(_rid) if _rid else None
@@ -3544,6 +3548,22 @@ def _spawn_confirm_expiry_watchdog(request_id: str,
                    str(_PENDING_CONFIRM_TTL_S), generation],
                   stdout=_sp.DEVNULL, stderr=_sp.DEVNULL,
                   stdin=_sp.DEVNULL, start_new_session=True)
+    except Exception:
+        pass
+
+
+def _release_confirm_claim(request_id: str) -> None:
+    """Child-ack (Q3, 2026-07-08): remove the confirm hook's claim marker(s)
+    for this request. Called by the confirmed turn RIGHT BEFORE it consumes
+    the single-use token — the point of commitment. A child that crashes
+    before here leaves the claim for the hook's reaper to restore, so the
+    operator's YES is not spent by a child that never redeemed it."""
+    try:
+        for c in _PENDING_CONFIRM_DIR.glob(f"{request_id}.claimed.*.json"):
+            try:
+                c.unlink()
+            except FileNotFoundError:
+                pass
     except Exception:
         pass
 

--- a/scripts/u1_print_start_gate.py
+++ b/scripts/u1_print_start_gate.py
@@ -504,8 +504,10 @@ def gcode_exists_on_printer(host, port, filename):
     """Does ``filename`` actually exist in the printer's gcodes storage?
 
     Returns True (confirmed present), False (confirmed ABSENT — Moonraker 404),
-    or None (couldn't verify: network/other error → the caller fails OPEN so a
-    flaky metadata query never blocks a real print).
+    or None (couldn't verify after retries: network/other error). Q1 (audit
+    2026-07-08): a single flaky query is absorbed by the retry loop; a
+    persistent None means the caller FAILS CLOSED — this close to a physical
+    start, can't-confirm means no. (This used to fail OPEN; it no longer does.)
 
     Why the gate needs this: the grace window fires an operator "print
     starting" notification BEFORE the actual start. A confused agent that
@@ -709,7 +711,7 @@ def _wait_pre_start_grace_period(cancel_marker: Path, grace_seconds: int,
                                  filename: str = '',
                                  notify_cmd: str | None = None,
                                  sleep_fn=None,
-                                 notify_fn=None) -> bool:
+                                 notify_fn=None) -> str:
     """Wait up to grace_seconds for cancel_marker to appear on disk.
 
     Returns a status string: ``'proceed'`` (start), ``'cancelled'`` (the
@@ -771,8 +773,25 @@ def _wait_pre_start_grace_period(cancel_marker: Path, grace_seconds: int,
                     pass
                 return 'notify_failed'
         else:
-            # Loop guard tripped: suppress the DM but STILL run the wait so the
-            # cancel safety net is intact. Audited so a real loop is visible.
+            # Q2 loop-guard alignment (audit 2026-07-09): the notify cap tripped,
+            # so NO countdown/CANCEL DM will be delivered and no
+            # /tmp/u1_pending_cancel/<rid>.json routing entry is created. Under
+            # Q2 we must not start a print the operator can neither see nor
+            # cancel — so treat an exhausted cap exactly like a hard notify
+            # failure: abort. (Previously this suppressed the DM but still ran
+            # the wait and returned 'proceed' — a real fail-open hole, since a
+            # gemma re-run storm can push grace_notify_count past the cap.) The
+            # escape hatch keeps the old suppress-and-proceed for opt-in setups.
+            if os.environ.get("U1_GRACE_NOTIFY_OPTIONAL", "") not in (
+                    "1", "true", "yes", "on"):
+                _audit_gate(request_id,
+                            'pre_start_grace_notify_loop_guard_abort',
+                            resolved_operator, cap=GRACE_NOTIFY_CAP)
+                try:
+                    (Path(f'/tmp/u1_pending_cancel/{request_id}.json')).unlink()
+                except Exception:
+                    pass
+                return 'notify_failed'
             _audit_gate(request_id, 'pre_start_grace_notify_suppressed_loop_guard',
                         resolved_operator, cap=GRACE_NOTIFY_CAP)
     # Contract with the Hermes gateway hook + notify script: the notify

--- a/scripts/u1_print_start_gate.py
+++ b/scripts/u1_print_start_gate.py
@@ -494,6 +494,12 @@ def start_print(host, port, filename):
     return post_json(f'http://{host}:{port}/printer/print/start', {'filename': filename})
 
 
+# Retry knobs for gcode_exists_on_printer (tests set these to run fast).
+_GCODE_EXISTS_ATTEMPTS = 3
+_GCODE_EXISTS_TIMEOUT = 8.0
+_GCODE_EXISTS_BACKOFF = 1.0
+
+
 def gcode_exists_on_printer(host, port, filename):
     """Does ``filename`` actually exist in the printer's gcodes storage?
 
@@ -510,17 +516,29 @@ def gcode_exists_on_printer(host, port, filename):
     fast, silent refusal — no notification.
     """
     import urllib.error
+    import time as _t
+    sleep = _t.sleep
     url = (f'http://{host}:{port}/server/files/metadata'
            f'?filename={urllib.parse.quote(str(filename))}')
-    try:
-        http_json(url, timeout=8.0)
-        return True
-    except urllib.error.HTTPError as exc:
-        if exc.code == 404:
-            return False
-        return None  # 500 etc. — can't be sure; fail open
-    except Exception:
-        return None  # unreachable / timeout — fail open (don't block real prints)
+    # Operator decision 2026-07-08: retry a few times, then FAIL CLOSED. A
+    # single transient blip (one 500 / one timeout) is absorbed by the
+    # retries — not "flaky enough" to block a legitimate print. A printer
+    # STILL unreachable after them is "broken", not "flaky", and this close
+    # to a physical start, unverifiable means no. A confirmed-absent file
+    # (404) is definitive and refuses immediately without retrying.
+    attempts = max(1, int(_GCODE_EXISTS_ATTEMPTS))
+    for _i in range(attempts):
+        try:
+            http_json(url, timeout=_GCODE_EXISTS_TIMEOUT)
+            return True
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                return False          # definitive — no retry
+        except Exception:
+            pass                      # unreachable / timeout — retry
+        if _i < attempts - 1:
+            sleep(_GCODE_EXISTS_BACKOFF)
+    return None                       # unverifiable after every attempt
 
 
 def _resolve_operator_for_gate(cli_operator: str | None) -> str:
@@ -694,13 +712,16 @@ def _wait_pre_start_grace_period(cancel_marker: Path, grace_seconds: int,
                                  notify_fn=None) -> bool:
     """Wait up to grace_seconds for cancel_marker to appear on disk.
 
-    Returns True if the caller should proceed to start_func, False if
-    the operator cancelled during the grace window (no HTTP call
-    should follow). Audit rows on both start and end. ``sleep_fn`` is
-    injected for tests so they don't actually sleep. ``notify_fn`` is
+    Returns a status string: ``'proceed'`` (start), ``'cancelled'`` (the
+    operator cancelled during the window), or ``'notify_failed'`` (a
+    configured countdown/CANCEL message could not be delivered, so the start
+    is aborted — Q2, operator decision 2026-07-08). Audit rows on both start
+    and end. ``sleep_fn`` is injected for tests so they don't actually sleep.
+    ``notify_fn`` is
     injected for tests so we don't shell out."""
     import time as _time
     _sleep = sleep_fn or _time.sleep
+    import os
     _notify = notify_fn or _run_grace_notify
     # Fresh window: any leftover marker from a prior request must be
     # cleared before we start listening.
@@ -727,12 +748,28 @@ def _wait_pre_start_grace_period(cancel_marker: Path, grace_seconds: int,
     # what the DM promised.
     if notify_cmd:
         if _grace_notify_allowed(request_id):
-            _notify(notify_cmd,
-                    request_id=request_id,
-                    filename=filename,
-                    grace_seconds=grace_seconds,
-                    cancel_marker=cancel_marker,
-                    operator=resolved_operator)
+            _nres = _notify(notify_cmd,
+                            request_id=request_id,
+                            filename=filename,
+                            grace_seconds=grace_seconds,
+                            cancel_marker=cancel_marker,
+                            operator=resolved_operator)
+            # Q2 (operator decision 2026-07-08): if a countdown/CANCEL DM was
+            # configured but could NOT be delivered, do not start a print the
+            # operator can neither see nor cancel — abort. Local-console runs
+            # (no notify_cmd) never reach here. Escape hatch:
+            # U1_GRACE_NOTIFY_OPTIONAL=1 restores the old fail-open behavior.
+            if (isinstance(_nres, dict) and not _nres.get("ok")
+                    and os.environ.get("U1_GRACE_NOTIFY_OPTIONAL", "") not in
+                    ("1", "true", "yes", "on")):
+                _audit_gate(request_id, 'pre_start_grace_notify_failed_abort',
+                            resolved_operator,
+                            stderr_tail=str(_nres.get("stderr_tail"))[:160])
+                try:
+                    (Path(f'/tmp/u1_pending_cancel/{request_id}.json')).unlink()
+                except Exception:
+                    pass
+                return 'notify_failed'
         else:
             # Loop guard tripped: suppress the DM but STILL run the wait so the
             # cancel safety net is intact. Audited so a real loop is visible.
@@ -753,7 +790,7 @@ def _wait_pre_start_grace_period(cancel_marker: Path, grace_seconds: int,
         except OSError:
             pass
 
-    def _cancelled() -> bool:
+    def _cancelled() -> str:
         _audit_gate(request_id, 'pre_start_grace_cancelled',
                     resolved_operator,
                     cancel_marker=str(cancel_marker),
@@ -769,7 +806,7 @@ def _wait_pre_start_grace_period(cancel_marker: Path, grace_seconds: int,
                 f"({filename})")
         except Exception:
             pass
-        return False
+        return 'cancelled'
 
     for _ in range(int(grace_seconds)):
         if cancel_marker.exists():
@@ -785,7 +822,7 @@ def _wait_pre_start_grace_period(cancel_marker: Path, grace_seconds: int,
                 resolved_operator, grace_seconds=grace_seconds,
                 proceeded_to_start=True)
     _clear_pending_state()
-    return True
+    return 'proceed'
 
 
 def run_gate(filename: str,
@@ -807,7 +844,7 @@ def run_gate(filename: str,
              grace_sleep_fn=None,
              grace_notify_cmd: str | None = None,
              grace_notify_fn=None,
-             gcode_exists_fn=gcode_exists_on_printer):
+             gcode_exists_fn=None):
     host = host or get_u1_host()
     port = port or get_u1_port()
     # Per-request token + photo storage: if we have a
@@ -1296,7 +1333,8 @@ def run_gate(filename: str,
     # Fails OPEN: only a CONFIRMED-absent file (Moonraker 404) refuses; a flaky
     # metadata query (None) proceeds so a transient error never blocks a real
     # print — the start itself still fails safely if the file is truly gone.
-    _exists = gcode_exists_fn(host, port, printer_filename)
+    _gcode_exists = gcode_exists_fn or gcode_exists_on_printer
+    _exists = _gcode_exists(host, port, printer_filename)
     if _exists is False:
         _audit_gate(request_id, 'gate_refused_file_missing',
                     resolved_operator, printer_storage_filename=printer_filename)
@@ -1309,6 +1347,22 @@ def run_gate(filename: str,
                 "gcode storage, so there is nothing to start. No notification "
                 "was sent. If you meant a real plate, re-run the workflow so "
                 "the sliced file is uploaded first."),
+        }
+    if _exists is None:
+        # Fail CLOSED (operator decision 2026-07-08): the printer could not
+        # confirm the file exists after several tries — unreachable or
+        # erroring. This close to a physical start, do not fire blind.
+        _audit_gate(request_id, 'gate_refused_file_unverifiable',
+                    resolved_operator, printer_storage_filename=printer_filename)
+        return {
+            'stage': 'gate_refused_file_unverifiable',
+            'filename': printer_filename,
+            'ok': False, 'started': False,
+            'reason': (
+                f"gate refuses: could not confirm {printer_filename!r} is on "
+                "the printer after several tries — the printer is unreachable "
+                "or erroring. Nothing was started and no notification was "
+                "sent. Check the printer is online, then re-run."),
         }
 
     def _grace_cancel_refusal() -> dict[str, Any]:
@@ -1349,13 +1403,27 @@ def run_gate(filename: str,
         # actually opened (vs. the child stalling in a pre-grace check).
         _write_gate_state(out_dir, 'grace_started', request_id=request_id,
                           grace_seconds=_resolved_grace)
-        if not _wait_pre_start_grace_period(
+        _grace_status = _wait_pre_start_grace_period(
                 cancel_marker, _resolved_grace, request_id,
                 resolved_operator,
                 filename=printer_filename,
                 notify_cmd=_resolved_notify,
                 sleep_fn=grace_sleep_fn,
-                notify_fn=grace_notify_fn):
+                notify_fn=grace_notify_fn)
+        if _grace_status == 'notify_failed':
+            return {
+                'stage': 'gate_refused_notify_undeliverable',
+                'filename': printer_filename,
+                'ok': False, 'started': False,
+                'reason': (
+                    "gate refuses: the pre-start countdown/CANCEL message "
+                    "could not be delivered, so the print was NOT started — "
+                    "you would have had no way to see it or cancel it. Fix "
+                    "the notifier (or check Telegram) and re-run. Set "
+                    "U1_GRACE_NOTIFY_OPTIONAL=1 to start anyway on notify "
+                    "failure."),
+            }
+        if _grace_status != 'proceed':
             return _grace_cancel_refusal()
         # Belt: one more marker check between the window closing and the
         # HTTP call — audit/log latency in the wait's exit path is real

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1175,3 +1175,70 @@ def test_form_handler_legacy_full_schema_still_works(monkeypatch, tmp_path):
     out = json.loads(mod._form_handler(
         {"form_schema": schema}, session_id="sess2"))
     assert out.get("user_answer") == {"parts": ["a"]}
+
+
+
+def test_form_tap_edit_strategy_v231(monkeypatch, tmp_path):
+    """v2.3.1 button responsiveness: a tap that only changes the SELECTION
+    (stays on the same screen) edits JUST the keyboard — snappy; a tap that
+    advances to a different screen edits the full message. The old code edited
+    the whole message on every tap, which Telegram throttled and made the
+    selection dot lag visibly behind the tap."""
+    pytest.importorskip("telegram")
+    import asyncio
+    _load_plugin_pkg(monkeypatch, tmp_path)
+    tp = importlib.import_module("hermes_plugins.u1_form.telegram_patch")
+    import u1_form as _u1form
+    import u1_form_telegram as tgr
+
+    cls = _fake_adapter_cls()
+    tp.ensure_patched(cls)
+    adapter = cls()
+    adapter._u1_form_state = {}
+
+    spec = {"parts": [{"id": "a", "label": "a"}, {"id": "b", "label": "b"}],
+            "tools": ["T0"], "materials": ["PLA"],
+            "profiles": [{"idx": 1, "label": "x"}],
+            "supports": ["supports", "no-supports"], "actions": ["start"]}
+    schema = _u1form.build_form_schema(spec)
+    form = tgr.new_form(schema)
+    screen0 = tgr.render_screen(form)
+    adapter._u1_form_state["fabc12"] = {
+        "form": form, "schema": schema, "session_key": "s",
+        "msg_id": 42, "chat_id": 7, "last_text": screen0["text"]}
+    parts_fi = next(i for i, f in enumerate(schema["fields"]) if f["id"] == "parts")
+
+    calls = []
+    class _Msg:
+        chat_id = 7
+        message_id = 42
+        text = screen0["text"]
+    class _Q:
+        def __init__(self, data):
+            self.data = data
+            self.message = _Msg()
+        async def answer(self, *a, **k):
+            pass
+        async def edit_message_text(self, *a, **k):
+            calls.append("text")
+        async def edit_message_reply_markup(self, *a, **k):
+            calls.append("markup")
+
+    async def tap(data):
+        await adapter._u1_handle_form_callback(
+            types.SimpleNamespace(callback_query=_Q(data)), None)
+
+    supports_fi = next(i for i, f in enumerate(schema["fields"])
+                       if f["id"] == "supports")
+
+    # 'Done' on parts ADVANCES to the setup group -> screen text changes ->
+    # full edit_message_text.
+    asyncio.run(tap("n:%d" % parts_fi))
+    assert calls == ["text"], f"screen advance must be a full edit, got {calls}"
+
+    # a grouped radio pick (supports) stays on the SAME setup screen and only
+    # moves the selection dot -> keyboard-only edit (the snappy path; this is
+    # the exact 'dot took forever' tap the operator hit on v2.3.0).
+    calls.clear()
+    asyncio.run(tap("s:%d:0" % supports_fi))
+    assert calls == ["markup"], f"dot-move tap must be keyboard-only, got {calls}"

--- a/tests/test_bed_clear_start_boundary.py
+++ b/tests/test_bed_clear_start_boundary.py
@@ -17,6 +17,17 @@ from types import SimpleNamespace
 
 import u1_kit_workflow as kw
 import u1_request
+import u1_print_start_gate as _gate_mod
+
+
+@pytest.fixture(autouse=True)
+def _gate_file_exists_by_default(monkeypatch):
+    """Q1 (2026-07-08): the gate FAILS CLOSED when it can't confirm the gcode
+    exists on the printer. Gate tests not about existence assume it's present
+    so they isolate their own logic; existence tests override in-body."""
+    monkeypatch.setattr(_gate_mod, "gcode_exists_on_printer",
+                        lambda *a, **k: True)
+
 
 
 @pytest.fixture(autouse=True)
@@ -1313,9 +1324,9 @@ def test_grace_notify_cmd_fired_when_window_opens(sandbox_requests, monkeypatch)
 
 
 def test_grace_notify_failure_does_not_block_start(sandbox_requests, monkeypatch):
-    """Notify command failure must NOT prevent the wait / start. The wait
-    is the safety net; notification is nice-to-have. Fail-open at notify
-    layer so the print doesn't blow up on Telegram outage."""
+    """Q2: a configured countdown/CANCEL that cannot be delivered ABORTS the
+    start (operator decision 2026-07-08) — a print the operator can neither
+    see nor cancel must not fire. Escape hatch tested separately."""
     import u1_print_start_gate as gate
     rid = "u1_test_notify_fail"
     _seed_request(sandbox_requests, rid,
@@ -1341,7 +1352,7 @@ def test_grace_notify_failure_does_not_block_start(sandbox_requests, monkeypatch
     def fake_notify_fail(cmd, **kw):
         return {"ok": False, "exit_code": 1, "stderr_tail": "network down"}
     start_hit = {"n": 0}
-    gate.run_gate(
+    res = gate.run_gate(
         "test_plate1.gcode", "start", host="127.0.0.1", port=7125,
         approval_token="test_token", stage2_approval_nonce="n",
         request_id=rid, operator="telegram:brent",
@@ -1351,9 +1362,47 @@ def test_grace_notify_failure_does_not_block_start(sandbox_requests, monkeypatch
         grace_notify_cmd="broken-cmd",
         grace_notify_fn=fake_notify_fail,
         out_dir=u1_request.request_dir(rid))
-    assert start_hit["n"] == 1, (
-        "notify failure must not block start_func — wait is the safety net, "
-        "notify is best-effort")
+    # Q2 (operator decision 2026-07-08): a configured countdown/CANCEL message
+    # that CANNOT be delivered aborts the start — never fire a print the
+    # operator can't see or cancel.
+    assert start_hit["n"] == 0, "undeliverable countdown must block the start"
+    assert res["started"] is False
+    assert res["stage"] == "gate_refused_notify_undeliverable"
+
+
+def test_grace_notify_failure_can_be_overridden_to_proceed(sandbox_requests, monkeypatch):
+    """The escape hatch: U1_GRACE_NOTIFY_OPTIONAL=1 restores the old fail-open
+    behavior for anyone who wants it (e.g. a headless/monitored setup)."""
+    import u1_print_start_gate as gate
+    monkeypatch.setenv("U1_GRACE_NOTIFY_OPTIONAL", "1")
+    rid = "u1_test_notify_optional"
+    _seed_request(sandbox_requests, rid,
+                  kit={"parts": [{"part_id": "p1"}], "part_count": 1},
+                  safety={"approval_token": "test_token",
+                          "stage2_approval_nonce": "n",
+                          "stage2_approval_binds": {
+                              "request_revision": 1,
+                              "gcode_hash": "sha256:abc123",
+                              "prompt_key": "bed_clear_start"}})
+    monkeypatch.setattr(gate, "_approval_token_valid", lambda stored, tok: (True, "ok"))
+    monkeypatch.setattr(gate, "preflight", lambda *a, **kw: [])
+    monkeypatch.setattr(gate, "query_state", lambda h, p: {})
+    monkeypatch.setattr(gate, "_read_approval_token", lambda d: {"token": "test_token"})
+    import u1_safety
+    monkeypatch.setattr(u1_safety, "can_start", lambda req: (True, "ok"))
+    monkeypatch.setattr(gate, "capture_real_bed_photo",
+                        lambda *a, **kw: {"ok": True, "brightness_check": "deferred"})
+    start_hit = {"n": 0}
+    gate.run_gate(
+        "test_plate1.gcode", "start", host="127.0.0.1", port=7125,
+        approval_token="test_token", stage2_approval_nonce="n",
+        request_id=rid, operator="telegram:brent",
+        start_func=lambda *a, **kw: start_hit.__setitem__("n", start_hit["n"]+1) or {"ok": True},
+        grace_seconds=2, grace_sleep_fn=lambda s: None,
+        grace_notify_cmd="broken-cmd",
+        grace_notify_fn=lambda cmd, **kw: {"ok": False, "exit_code": 1, "stderr_tail": "down"},
+        out_dir=u1_request.request_dir(rid))
+    assert start_hit["n"] == 1  # opt-out honored: start proceeds
 
 
 def test_grace_no_notify_cmd_still_works(sandbox_requests, monkeypatch):

--- a/tests/test_bed_clear_start_boundary.py
+++ b/tests/test_bed_clear_start_boundary.py
@@ -1405,6 +1405,78 @@ def test_grace_notify_failure_can_be_overridden_to_proceed(sandbox_requests, mon
     assert start_hit["n"] == 1  # opt-out honored: start proceeds
 
 
+def _seed_loop_guard_request(sandbox_requests, rid):
+    """Seed a request already AT the notify cap (grace_notify_count == cap), so
+    the next start attempt trips _grace_notify_allowed -> False."""
+    import u1_print_start_gate as gate
+    _seed_request(sandbox_requests, rid,
+                  kit={"parts": [{"part_id": "p1"}], "part_count": 1},
+                  safety={"approval_token": "test_token",
+                          "stage2_approval_nonce": "n",
+                          "grace_notify_count": gate.GRACE_NOTIFY_CAP,
+                          "stage2_approval_binds": {
+                              "request_revision": 1,
+                              "gcode_hash": "sha256:abc123",
+                              "prompt_key": "bed_clear_start"}})
+
+
+def _stub_gate_ready(monkeypatch, gate):
+    monkeypatch.setattr(gate, "_approval_token_valid", lambda stored, tok: (True, "ok"))
+    monkeypatch.setattr(gate, "preflight", lambda *a, **kw: [])
+    monkeypatch.setattr(gate, "query_state", lambda h, p: {})
+    monkeypatch.setattr(gate, "_read_approval_token", lambda d: {"token": "test_token"})
+    import u1_safety
+    monkeypatch.setattr(u1_safety, "can_start", lambda req: (True, "ok"))
+    monkeypatch.setattr(gate, "capture_real_bed_photo",
+                        lambda *a, **kw: {"ok": True, "brightness_check": "deferred"})
+
+
+def test_grace_notify_loop_guard_exhaustion_aborts(sandbox_requests, monkeypatch):
+    """AUDIT #1: when the notify loop guard trips (a re-run storm pushes
+    grace_notify_count past the cap), NO countdown/CANCEL DM is delivered — so
+    per Q2 the start must ABORT, not silently suppress the DM and proceed. The
+    notify_fn is intentionally a SUCCESS: proving it's the loop guard, not a
+    delivery failure, that blocks the start."""
+    import u1_print_start_gate as gate
+    rid = "u1_test_loop_guard_abort"
+    _seed_loop_guard_request(sandbox_requests, rid)
+    _stub_gate_ready(monkeypatch, gate)
+    start_hit = {"n": 0}
+    res = gate.run_gate(
+        "test_plate1.gcode", "start", host="127.0.0.1", port=7125,
+        approval_token="test_token", stage2_approval_nonce="n",
+        request_id=rid, operator="telegram:brent",
+        start_func=lambda *a, **kw: start_hit.__setitem__("n", start_hit["n"]+1) or {"ok": True},
+        grace_seconds=2, grace_sleep_fn=lambda s: None,
+        grace_notify_cmd="some-cmd",
+        grace_notify_fn=lambda cmd, **kw: {"ok": True},   # delivery WOULD succeed
+        out_dir=u1_request.request_dir(rid))
+    assert start_hit["n"] == 0, "loop-guard suppression must not start a blind print"
+    assert res["started"] is False
+    assert res["stage"] == "gate_refused_notify_undeliverable"
+
+
+def test_grace_notify_loop_guard_exhaustion_can_be_overridden(sandbox_requests, monkeypatch):
+    """Same escape hatch applies to the loop-guard path: U1_GRACE_NOTIFY_OPTIONAL=1
+    restores suppress-and-proceed for opt-in setups."""
+    import u1_print_start_gate as gate
+    monkeypatch.setenv("U1_GRACE_NOTIFY_OPTIONAL", "1")
+    rid = "u1_test_loop_guard_optional"
+    _seed_loop_guard_request(sandbox_requests, rid)
+    _stub_gate_ready(monkeypatch, gate)
+    start_hit = {"n": 0}
+    gate.run_gate(
+        "test_plate1.gcode", "start", host="127.0.0.1", port=7125,
+        approval_token="test_token", stage2_approval_nonce="n",
+        request_id=rid, operator="telegram:brent",
+        start_func=lambda *a, **kw: start_hit.__setitem__("n", start_hit["n"]+1) or {"ok": True},
+        grace_seconds=2, grace_sleep_fn=lambda s: None,
+        grace_notify_cmd="some-cmd",
+        grace_notify_fn=lambda cmd, **kw: {"ok": True},
+        out_dir=u1_request.request_dir(rid))
+    assert start_hit["n"] == 1  # opt-out honored
+
+
 def test_grace_no_notify_cmd_still_works(sandbox_requests, monkeypatch):
     """No notify command configured → grace period still runs cleanly.
     Nobody gets notified, but the SSH-touch cancel path still works."""

--- a/tests/test_model_free_yes.py
+++ b/tests/test_model_free_yes.py
@@ -164,8 +164,10 @@ def test_single_window_yes_spawns_and_single_fires(pending_dir, monkeypatch):
     _run(_ctx("Yes!"))
     assert spawned == [_expected_cmd(entry["request_id"])]
     assert not (pending_dir / f"{entry['request_id']}.json").exists()
-    assert list(pending_dir.iterdir()) == []  # no claimed leftovers either
-    # a second YES finds nothing — no double spawn
+    # Q3: the claim is RETAINED for the child (not deleted on spawn); its pid
+    # is this live test process, so the reaper leaves it and a second YES
+    # still finds no armed window (claimed files are never windows).
+    assert len(list(pending_dir.glob(f"{entry['request_id']}.claimed.*.json"))) == 1
     _run(_ctx())
     assert len(spawned) == 1
 
@@ -329,7 +331,8 @@ def test_spawn_failure_restores_marker(pending_dir, monkeypatch, tmp_path):
                         lambda cmd, **kw_: spawned.append(cmd) or SimpleNamespace(pid=1))
     _run(_ctx())
     assert spawned == [_expected_cmd(entry["request_id"])]
-    assert list(pending_dir.iterdir()) == []
+    # Q3: successful retry retains the claim for the child
+    assert len(list(pending_dir.glob("*.claimed.*.json"))) == 1
 
 
 def test_second_yes_mid_claim_finds_nothing(pending_dir, monkeypatch):
@@ -353,9 +356,12 @@ def test_stale_claimed_file_is_not_a_window(pending_dir, monkeypatch):
     """A .claimed. file (in-flight or crashed spawn) never counts as an
     armed window."""
     pending_dir.mkdir(parents=True, exist_ok=True)
+    import os as _os
     entry = _marker(pending_dir)
     src = pending_dir / f"{entry['request_id']}.json"
-    src.rename(pending_dir / f"{entry['request_id']}.claimed.4242.json")
+    # a LIVE pid = confirm genuinely in flight -> never a window (the reaper
+    # only restores claims whose pid is dead).
+    src.rename(pending_dir / f"{entry['request_id']}.claimed.{_os.getpid()}.json")
     spawned = []
     monkeypatch.setattr(hook.subprocess, "Popen",
                         lambda cmd, **kw_: spawned.append(cmd))
@@ -763,3 +769,75 @@ def test_arm_spawns_expiry_watchdog(pending_dir, tmp_path, monkeypatch):
                         lambda: ("telegram", "8131922235"))
     kw._arm_pending_confirm("u1_2026_0707_wd0001", "p.gcode", "brent")
     assert calls == [("u1_2026_0707_wd0001", "p.gcode")]
+
+
+
+# ---------- Q3: child-ack + orphan claim reaper (2026-07-08) ----------
+
+def _dead_pid():
+    import subprocess as _sp
+    d = _sp.Popen(["true"]); d.wait()
+    return d.pid           # reliably dead now
+
+
+def test_spawn_leaves_claim_for_child(pending_dir, monkeypatch):
+    """Q3: the hook no longer deletes the claim on spawn — the child owns it.
+    Previously the YES was consumed the instant Popen returned."""
+    entry = _marker(pending_dir)
+    spawned = []
+    monkeypatch.setattr(hook.subprocess, "Popen",
+                        lambda cmd, **kw_: spawned.append(cmd) or SimpleNamespace(pid=1))
+    asyncio.run(hook.handle("agent:start", _ctx()))
+    assert spawned, "should have spawned"
+    rid = entry["request_id"]
+    assert not (pending_dir / f"{rid}.json").exists()          # renamed to claim
+    claims = list(pending_dir.glob(f"{rid}.claimed.*.json"))
+    assert len(claims) == 1, "claim must be RETAINED, not deleted on spawn"
+
+
+def test_reaper_restores_orphaned_claim(pending_dir):
+    """A claim with a dead pid + live window = child crashed before consuming
+    -> restore so the operator's next YES retries."""
+    rid = "u1_2026_0708_cafe01"
+    pending_dir.mkdir(parents=True, exist_ok=True)
+    claim = pending_dir / f"{rid}.claimed.{_dead_pid()}.json"
+    claim.write_text(json.dumps({"request_id": rid,
+        "expires_at": (datetime.now(timezone.utc)+timedelta(minutes=5)).isoformat()}))
+    hook._reap_orphaned_claims()
+    assert not claim.exists()
+    assert (pending_dir / f"{rid}.json").exists(), "orphan must be restored"
+
+
+def test_reaper_leaves_live_claim_alone(pending_dir, monkeypatch):
+    """A claim with a LIVE pid = confirm in flight -> untouched."""
+    rid = "u1_2026_0708_cafe02"
+    monkeypatch.setattr(hook, "_pid_alive", lambda pid: True)
+    pending_dir.mkdir(parents=True, exist_ok=True)
+    claim = pending_dir / f"{rid}.claimed.4242.json"
+    claim.write_text(json.dumps({"request_id": rid,
+        "expires_at": (datetime.now(timezone.utc)+timedelta(minutes=5)).isoformat()}))
+    hook._reap_orphaned_claims()
+    assert claim.exists()
+    assert not (pending_dir / f"{rid}.json").exists()
+
+
+def test_reaper_drops_expired_orphan_without_restoring(pending_dir):
+    """Dead pid but the window already expired -> drop, do NOT restore a
+    dead window."""
+    rid = "u1_2026_0708_cafe03"
+    pending_dir.mkdir(parents=True, exist_ok=True)
+    claim = pending_dir / f"{rid}.claimed.{_dead_pid()}.json"
+    claim.write_text(json.dumps({"request_id": rid,
+        "expires_at": (datetime.now(timezone.utc)-timedelta(minutes=5)).isoformat()}))
+    hook._reap_orphaned_claims()
+    assert not claim.exists()
+    assert not (pending_dir / f"{rid}.json").exists()
+
+
+def test_release_confirm_claim_removes_the_claim(pending_dir):
+    """The child releases its own claim at the commitment point."""
+    rid = "u1_2026_0708_cafe04"
+    pending_dir.mkdir(parents=True, exist_ok=True)
+    (pending_dir / f"{rid}.claimed.111.json").write_text("{}")
+    kw._release_confirm_claim(rid)
+    assert not list(pending_dir.glob(f"{rid}.claimed.*.json"))

--- a/tests/test_model_free_yes.py
+++ b/tests/test_model_free_yes.py
@@ -845,6 +845,28 @@ def test_spawn_records_actual_child_pid_not_gateway(pending_dir, monkeypatch):
     assert cid != str(_os.getpid())
 
 
+def test_fast_child_commit_is_not_recreated_by_parent(pending_dir, monkeypatch):
+    """Follow-up audit race: a fast child can reach its commitment point and
+    DELETE its claim before the parent records the child pid. The parent must
+    NOT recreate the claim — recreating it would let the reaper later 'restore'
+    a dead confirmation window. Popen here simulates the child committing
+    (deleting the exact claim) before it returns."""
+    entry = _marker(pending_dir)
+    rid = entry["request_id"]
+
+    def _popen_child_commits_immediately(cmd, **kw_):
+        for c in pending_dir.glob(f"{rid}.claimed.*.json"):
+            c.unlink()                      # child released its claim
+        return SimpleNamespace(pid=555000)
+
+    monkeypatch.setattr(hook.subprocess, "Popen", _popen_child_commits_immediately)
+    asyncio.run(hook.handle("agent:start", _ctx()))
+    assert not list(pending_dir.glob(f"{rid}.claimed.*.json")), \
+        "parent must not recreate a claim the child already committed"
+    assert not (pending_dir / f"{rid}.json").exists(), \
+        "a committed confirmation must not be re-armed"
+
+
 def test_reaper_restores_orphaned_claim(pending_dir):
     """Dead CHILD pid + live window = child crashed before consuming -> restore."""
     rid = "u1_2026_0708_cafe01"

--- a/tests/test_model_free_yes.py
+++ b/tests/test_model_free_yes.py
@@ -126,6 +126,19 @@ def _expected_cmd(rid):
             "--confirm-start-for", rid, "--json-events"]
 
 
+def _strip_claim_id(cmd):
+    """Drop the --confirm-claim-id <uuid> pair so an argv can be compared to
+    the fixed _expected_cmd shape (the id is a random per-spawn uuid)."""
+    out, i = [], 0
+    while i < len(cmd):
+        if cmd[i] == "--confirm-claim-id":
+            i += 2
+            continue
+        out.append(cmd[i])
+        i += 1
+    return out
+
+
 def _hook_log(tmp_path):
     p = tmp_path / "hook.log"
     if not p.exists():
@@ -162,7 +175,7 @@ def test_single_window_yes_spawns_and_single_fires(pending_dir, monkeypatch):
     monkeypatch.setattr(hook.subprocess, "Popen",
                         lambda cmd, **kw_: spawned.append(cmd) or SimpleNamespace(pid=1))
     _run(_ctx("Yes!"))
-    assert spawned == [_expected_cmd(entry["request_id"])]
+    assert [_strip_claim_id(c) for c in spawned] == [_expected_cmd(entry["request_id"])]
     assert not (pending_dir / f"{entry['request_id']}.json").exists()
     # Q3: the claim is RETAINED for the child (not deleted on spawn); its pid
     # is this live test process, so the reaper leaves it and a second YES
@@ -183,7 +196,7 @@ def test_bare_yes_with_two_windows_refuses(pending_dir, monkeypatch):
     assert len(list(pending_dir.glob("*.json"))) == 2
     # code-scoped yes picks exactly one
     _run(_ctx("yes bbb222"))
-    assert spawned == [_expected_cmd("u1_2026_0707_bbb222")]
+    assert [_strip_claim_id(c) for c in spawned] == [_expected_cmd("u1_2026_0707_bbb222")]
     assert (pending_dir / "u1_2026_0707_aaa111.json").exists()
 
 
@@ -209,7 +222,7 @@ def test_hostile_confirm_cmd_field_is_ignored(pending_dir, monkeypatch):
     monkeypatch.setattr(hook.subprocess, "Popen",
                         lambda cmd, **kw_: spawned.append(cmd) or SimpleNamespace(pid=1))
     _run(_ctx())
-    assert spawned == [_expected_cmd(entry["request_id"])]
+    assert [_strip_claim_id(c) for c in spawned] == [_expected_cmd(entry["request_id"])]
 
 
 @pytest.mark.parametrize("bad_rid", [
@@ -255,7 +268,7 @@ def test_yes_from_bound_operator_spawns(pending_dir, monkeypatch):
     monkeypatch.setattr(hook.subprocess, "Popen",
                         lambda cmd, **kw_: spawned.append(cmd) or SimpleNamespace(pid=1))
     _run(_ctx(platform=_OP_PLATFORM, user_id=_OP_USER))
-    assert spawned == [_expected_cmd(entry["request_id"])]
+    assert [_strip_claim_id(c) for c in spawned] == [_expected_cmd(entry["request_id"])]
 
 
 def test_yes_from_wrong_user_refuses(pending_dir, monkeypatch, tmp_path):
@@ -307,7 +320,7 @@ def test_int_user_id_normalizes_against_marker_string(pending_dir, monkeypatch):
     monkeypatch.setattr(hook.subprocess, "Popen",
                         lambda cmd, **kw_: spawned.append(cmd) or SimpleNamespace(pid=1))
     _run(_ctx(user_id=int(_OP_USER)))
-    assert spawned == [_expected_cmd(entry["request_id"])]
+    assert [_strip_claim_id(c) for c in spawned] == [_expected_cmd(entry["request_id"])]
 
 
 # ---------- claim-then-spawn ----------
@@ -330,7 +343,7 @@ def test_spawn_failure_restores_marker(pending_dir, monkeypatch, tmp_path):
     monkeypatch.setattr(hook.subprocess, "Popen",
                         lambda cmd, **kw_: spawned.append(cmd) or SimpleNamespace(pid=1))
     _run(_ctx())
-    assert spawned == [_expected_cmd(entry["request_id"])]
+    assert [_strip_claim_id(c) for c in spawned] == [_expected_cmd(entry["request_id"])]
     # Q3: successful retry retains the claim for the child
     assert len(list(pending_dir.glob("*.claimed.*.json"))) == 1
 
@@ -795,47 +808,95 @@ def test_spawn_leaves_claim_for_child(pending_dir, monkeypatch):
     assert len(claims) == 1, "claim must be RETAINED, not deleted on spawn"
 
 
-def test_reaper_restores_orphaned_claim(pending_dir):
-    """A claim with a dead pid + live window = child crashed before consuming
-    -> restore so the operator's next YES retries."""
-    rid = "u1_2026_0708_cafe01"
+def _claim(pending_dir, rid, cid, *, child_pid=None, minutes=5, body=None):
+    """Write a claim file the reaper's way: opaque claim_id filename, liveness
+    in the CONTENT as child_pid (audit 2026-07-09)."""
     pending_dir.mkdir(parents=True, exist_ok=True)
-    claim = pending_dir / f"{rid}.claimed.{_dead_pid()}.json"
-    claim.write_text(json.dumps({"request_id": rid,
-        "expires_at": (datetime.now(timezone.utc)+timedelta(minutes=5)).isoformat()}))
+    st = {"request_id": rid,
+          "expires_at": (datetime.now(timezone.utc)
+                         + timedelta(minutes=minutes)).isoformat()}
+    if child_pid is not None:
+        st["child_pid"] = child_pid
+    if body:
+        st.update(body)
+    f = pending_dir / f"{rid}.claimed.{cid}.json"
+    f.write_text(json.dumps(st))
+    return f
+
+
+def test_spawn_records_actual_child_pid_not_gateway(pending_dir, monkeypatch):
+    """AUDIT #2 handoff assertion: the pid the reaper checks must be the CHILD's
+    Popen pid, NOT os.getpid() (the gateway, always alive). This is the exact
+    assertion the original tests lacked, which let the broken handoff pass."""
+    import os as _os
+    entry = _marker(pending_dir)
+    CHILD_PID = 991234
+    monkeypatch.setattr(hook.subprocess, "Popen",
+                        lambda cmd, **kw_: SimpleNamespace(pid=CHILD_PID))
+    asyncio.run(hook.handle("agent:start", _ctx()))
+    rid = entry["request_id"]
+    claims = list(pending_dir.glob(f"{rid}.claimed.*.json"))
+    assert len(claims) == 1
+    st = json.loads(claims[0].read_text())
+    assert st.get("child_pid") == CHILD_PID, "must record the Popen child pid"
+    assert st.get("child_pid") != _os.getpid(), "must NOT be the gateway pid"
+    # filename is an opaque claim_id, not a pid
+    cid = claims[0].name.rsplit(".claimed.", 1)[1].split(".")[0]
+    assert cid != str(_os.getpid())
+
+
+def test_reaper_restores_orphaned_claim(pending_dir):
+    """Dead CHILD pid + live window = child crashed before consuming -> restore."""
+    rid = "u1_2026_0708_cafe01"
+    claim = _claim(pending_dir, rid, "abc123", child_pid=_dead_pid())
     hook._reap_orphaned_claims()
     assert not claim.exists()
     assert (pending_dir / f"{rid}.json").exists(), "orphan must be restored"
 
 
 def test_reaper_leaves_live_claim_alone(pending_dir, monkeypatch):
-    """A claim with a LIVE pid = confirm in flight -> untouched."""
+    """A claim whose recorded CHILD pid is alive = confirm in flight -> untouched."""
     rid = "u1_2026_0708_cafe02"
     monkeypatch.setattr(hook, "_pid_alive", lambda pid: True)
-    pending_dir.mkdir(parents=True, exist_ok=True)
-    claim = pending_dir / f"{rid}.claimed.4242.json"
-    claim.write_text(json.dumps({"request_id": rid,
-        "expires_at": (datetime.now(timezone.utc)+timedelta(minutes=5)).isoformat()}))
+    claim = _claim(pending_dir, rid, "def456", child_pid=4242)
     hook._reap_orphaned_claims()
     assert claim.exists()
     assert not (pending_dir / f"{rid}.json").exists()
 
 
 def test_reaper_drops_expired_orphan_without_restoring(pending_dir):
-    """Dead pid but the window already expired -> drop, do NOT restore a
-    dead window."""
+    """Dead child pid but window expired -> drop, do NOT restore a dead window."""
     rid = "u1_2026_0708_cafe03"
-    pending_dir.mkdir(parents=True, exist_ok=True)
-    claim = pending_dir / f"{rid}.claimed.{_dead_pid()}.json"
-    claim.write_text(json.dumps({"request_id": rid,
-        "expires_at": (datetime.now(timezone.utc)-timedelta(minutes=5)).isoformat()}))
+    claim = _claim(pending_dir, rid, "ghi789", child_pid=_dead_pid(), minutes=-5)
     hook._reap_orphaned_claims()
     assert not claim.exists()
     assert not (pending_dir / f"{rid}.json").exists()
 
 
-def test_release_confirm_claim_removes_the_claim(pending_dir):
-    """The child releases its own claim at the commitment point."""
+def test_reaper_skips_fresh_claim_before_pid_recorded(pending_dir):
+    """A just-created claim with no child_pid yet = spawn in flight -> left
+    alone during the mtime grace (do not reap a confirm that is bootstrapping)."""
+    rid = "u1_2026_0709_inflight"
+    claim = _claim(pending_dir, rid, "fresh1")   # no child_pid
+    hook._reap_orphaned_claims()
+    assert claim.exists(), "fresh no-pid claim is in flight, not an orphan"
+    assert not (pending_dir / f"{rid}.json").exists()
+
+
+def test_release_scoped_to_own_claim_id(pending_dir):
+    """AUDIT #3: a child releases ONLY its own claim_id — a concurrently
+    re-armed generation's claim survives instead of being deleted."""
+    rid = "u1_2026_0709_gen001"
+    pending_dir.mkdir(parents=True, exist_ok=True)
+    (pending_dir / f"{rid}.claimed.AAA.json").write_text("{}")
+    (pending_dir / f"{rid}.claimed.BBB.json").write_text("{}")
+    kw._release_confirm_claim(rid, "AAA")
+    assert not (pending_dir / f"{rid}.claimed.AAA.json").exists(), "own claim gone"
+    assert (pending_dir / f"{rid}.claimed.BBB.json").exists(), "other generation kept"
+
+
+def test_release_confirm_claim_legacy_glob_without_id(pending_dir):
+    """No claim_id (direct/legacy call) falls back to the request-wide glob."""
     rid = "u1_2026_0708_cafe04"
     pending_dir.mkdir(parents=True, exist_ok=True)
     (pending_dir / f"{rid}.claimed.111.json").write_text("{}")

--- a/tests/test_reprint.py
+++ b/tests/test_reprint.py
@@ -326,3 +326,53 @@ def test_confirm_turn_refuses_on_printer_file_drift(monkeypatch, capsys):
     assert "gate" not in reached, "gate must not launch on drifted bytes"
     assert out_res["phase"] == "bed_clear_approval_rejected"
     assert "changed since upload" in out
+
+
+
+def test_normal_kit_confirm_skips_reingest(monkeypatch, capsys):
+    """Live 2026-07-08: a normal (non-reprint) kit's YES returned
+    'awaiting_parts'. gemma re-ran the kit command mid-flow, which left
+    kit.selected unset; the confirm turn then RE-INGESTED and re-prompted for
+    parts instead of starting. A confirmed start must route straight to the
+    gate — never re-ingest — regardless of kit.selected, since everything it
+    validates is already persisted."""
+    from types import SimpleNamespace
+    old_rid, fname = _seed_uploaded_request()
+    # make it a NORMAL kit at the bed-clear boundary: no reprint_of, and the
+    # exact bug state — kit.selected unset.
+    st = u1_request.read_request(old_rid)
+    st.pop("reprint_of", None)
+    kitblk = dict(st.get("kit") or {}); kitblk["selected"] = None
+    tok = u1_form.new_confirm_token()
+    pending = dict((st.get("safety") or {}).get("pending_bed_clear_start") or {})
+    pending.update({"nonce": "n0", "confirm_token": tok,
+                    "prompt_key": "bed_clear_start",
+                    "request_revision": st.get("request_revision", 1),
+                    "gcode_hash": st["plates"][0]["gcode_hash"]})
+    safety = dict(st.get("safety") or {})
+    safety["pending_bed_clear_start"] = pending
+    safety.setdefault("approval_token", "tok_test")       # bed-clear emit sets this
+    safety.setdefault("bed_clear_photo_captured", True)
+    u1_request.write_request(old_rid, kit=kitblk, safety=safety,
+                             gcode_hash=st["plates"][0]["gcode_hash"],
+                             phase="awaiting_bed_clear_start")
+    u1_form.persist_confirm_token(tok, old_rid)
+
+    reached = {}
+    def _fake_gate(gate_py, argv, out_dir):
+        reached["argv"] = argv
+        return None  # None == grace window opened, gate detached
+    monkeypatch.setattr(kw, "_invoke_stage2_gate", _fake_gate)
+
+    args = SimpleNamespace(
+        model=None, confirm_start=None, confirm_start_for=old_rid,
+        reprint=False, reprint_start=None, grace_cancel=False,
+        json_events=True, operator="test-op", events_file=None,
+        request_id=None, action=None, bed_clear_confirmed=False,
+        pending_nonce=None, nozzle="0.4",
+    )
+    out_res = kw.run_kit_workflow(args)
+    out = capsys.readouterr().out
+    assert reached, f"confirm must reach the gate, not re-prompt; res={out_res} out={out[:300]}"
+    assert "awaiting_parts" not in out and "awaiting_parts" != out_res.get("phase")
+    assert "kit_ingested" not in out            # NO re-ingest on the confirm turn

--- a/tests/test_u1_print_start_gate.py
+++ b/tests/test_u1_print_start_gate.py
@@ -1,3 +1,23 @@
+
+
+import pytest as _pytest_fx
+
+
+@_pytest_fx.fixture(autouse=True)
+def _gate_file_exists_by_default(request, monkeypatch):
+    """Q1 (2026-07-08): the gate now FAILS CLOSED when it can't confirm the
+    gcode exists on the printer. Gate tests that aren't about existence
+    should assume the file is present so they isolate their own logic. Tests
+    that exercise the real gcode_exists_on_printer opt out with
+    @pytest.mark.real_gcode_exists."""
+    if request.node.get_closest_marker("real_gcode_exists"):
+        return
+    try:
+        import u1_print_start_gate as _gate
+        monkeypatch.setattr(_gate, "gcode_exists_on_printer",
+                            lambda *a, **k: True)
+    except Exception:
+        pass
 import hashlib
 import io
 import json
@@ -343,8 +363,11 @@ def test_gate_proceeds_when_file_exists(monkeypatch, tmp_path):
     assert res2['started'] is True and started['s'] is True
 
 
-def test_gate_fails_open_when_existence_unverifiable(monkeypatch, tmp_path):
-    # A flaky metadata query (None) must NOT block a real print.
+def test_gate_fails_closed_when_existence_unverifiable(monkeypatch, tmp_path):
+    # Q1 (operator decision 2026-07-08): after the retries, a still-
+    # unverifiable file (None) REFUSES — this close to a physical start,
+    # can't-confirm means no. A single blip is absorbed by the retries; a
+    # persistent None means the printer is unreachable/erroring.
     monkeypatch.setattr(g, 'query_state', lambda h, p: idle())
     monkeypatch.setattr(g, 'capture_real_bed_photo', _fake_capture(success=True))
     rid = _seed_can_start_passing_request()
@@ -357,9 +380,12 @@ def test_gate_fails_open_when_existence_unverifiable(monkeypatch, tmp_path):
                       approval_token=token, request_id=rid, grace_seconds=0,
                       gcode_exists_fn=lambda *a: None,   # couldn't verify
                       start_func=lambda *a: started.__setitem__('s', True) or {'result': 'ok'})
-    assert res2['started'] is True
+    assert res2['started'] is False
+    assert res2['stage'] == 'gate_refused_file_unverifiable'
+    assert started['s'] is False
 
 
+@_pytest_fx.mark.real_gcode_exists
 def test_gcode_exists_on_printer_maps_404_to_false(monkeypatch):
     import urllib.error
     def _raise_404(url, timeout=10.0):
@@ -368,6 +394,7 @@ def test_gcode_exists_on_printer_maps_404_to_false(monkeypatch):
     assert g.gcode_exists_on_printer('h', 1, 'nope.gcode') is False
 
 
+@_pytest_fx.mark.real_gcode_exists
 def test_gcode_exists_on_printer_present_and_unreachable(monkeypatch):
     monkeypatch.setattr(g, 'http_json', lambda url, timeout=10.0: {'result': {'size': 1}})
     assert g.gcode_exists_on_printer('h', 1, 'real.gcode') is True
@@ -491,3 +518,50 @@ def test_consume_stage2_nonce_fails_closed_on_exception(monkeypatch, tmp_path):
         raise OSError("simulated fs failure under the lock")
     monkeypatch.setattr(u1_request, "ensure_request_dir", _boom)
     assert g._consume_stage2_nonce("u1_2026_0101_abcdef", "some-nonce") is False
+
+
+@_pytest_fx.mark.real_gcode_exists
+def test_gcode_exists_retries_then_fails_closed(monkeypatch):
+    """A printer that stays unreachable across every attempt -> None
+    (caller fails closed). Proves 'broken, not flaky' is caught."""
+    import u1_print_start_gate as gate, urllib.error
+    calls = {"n": 0}
+    def _always_fail(url, timeout=8.0):
+        calls["n"] += 1
+        raise urllib.error.URLError("unreachable")
+    monkeypatch.setattr(gate, "http_json", _always_fail)
+    monkeypatch.setattr(gate, "_GCODE_EXISTS_ATTEMPTS", 3)
+    monkeypatch.setattr(gate, "_GCODE_EXISTS_BACKOFF", 0)  # instant
+    assert gate.gcode_exists_on_printer("h", 1, "f.gcode") is None
+    assert calls["n"] == 3, "must retry every attempt before giving up"
+
+
+@_pytest_fx.mark.real_gcode_exists
+def test_gcode_exists_transient_blip_is_absorbed(monkeypatch):
+    """One blip then success -> True. Proves a single flake never blocks
+    a legit print (the operator's concern)."""
+    import u1_print_start_gate as gate, urllib.error
+    seq = {"n": 0}
+    def _blip_then_ok(url, timeout=8.0):
+        seq["n"] += 1
+        if seq["n"] == 1:
+            raise urllib.error.URLError("one blip")
+        return {"result": {}}
+    monkeypatch.setattr(gate, "http_json", _blip_then_ok)
+    monkeypatch.setattr(gate, "_GCODE_EXISTS_BACKOFF", 0)
+    assert gate.gcode_exists_on_printer("h", 1, "f.gcode") is True
+    assert seq["n"] == 2, "second attempt succeeds after the blip"
+
+
+@_pytest_fx.mark.real_gcode_exists
+def test_gcode_exists_404_refuses_without_retry(monkeypatch):
+    """A definitive 'absent' (404) refuses immediately — no retries, no wait."""
+    import u1_print_start_gate as gate, urllib.error
+    calls = {"n": 0}
+    def _404(url, timeout=8.0):
+        calls["n"] += 1
+        raise urllib.error.HTTPError(url, 404, "Not Found", {}, None)
+    monkeypatch.setattr(gate, "http_json", _404)
+    monkeypatch.setattr(gate, "_GCODE_EXISTS_BACKOFF", 0)
+    assert gate.gcode_exists_on_printer("h", 1, "gone.gcode") is False
+    assert calls["n"] == 1, "404 is definitive — do not retry"

--- a/tests/test_u1_safety.py
+++ b/tests/test_u1_safety.py
@@ -10,6 +10,15 @@ import pytest
 
 import u1_audit
 import u1_print_start_gate as g
+
+
+@pytest.fixture(autouse=True)
+def _gate_file_exists_by_default(monkeypatch):
+    """Q1 (2026-07-08): the gate FAILS CLOSED when it can't confirm the gcode
+    exists on the printer. These safety-path tests assume the file is present
+    so they exercise the approval/audit logic, not the existence check."""
+    monkeypatch.setattr(g, "gcode_exists_on_printer", lambda *a, **k: True)
+
 import u1_request
 import u1_safety
 

--- a/tools/hermes_hooks/u1_confirm_start/handler.py
+++ b/tools/hermes_hooks/u1_confirm_start/handler.py
@@ -169,6 +169,70 @@ def _delete_marker(p: Path, event: str, **details) -> None:
               "error": f"{type(exc).__name__}: {exc}", **details})
 
 
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True          # exists, owned by someone else — treat as alive
+    except Exception:
+        return True          # unknown — do not reap on uncertainty
+
+
+def _reap_orphaned_claims() -> None:
+    """Restore a claim whose child died BEFORE releasing it (Q3, 2026-07-08).
+
+    A `<rid>.claimed.<pid>.json` still on disk with a DEAD pid means the child
+    crashed before it reached the token-consume point (where it removes its
+    own claim), so the operator's YES was never actually spent. Rename it back
+    to `<rid>.json` if the window is still live, else delete it. A live pid is
+    a confirm in flight — left alone."""
+    if not PENDING_DIR.exists():
+        return
+    now = datetime.now(timezone.utc)
+    for p in list(PENDING_DIR.iterdir()):
+        if not p.is_file() or ".claimed." not in p.name:
+            continue
+        # filename: <rid>.claimed.<pid>.json
+        try:
+            pid = int(p.name.rsplit(".claimed.", 1)[1].split(".")[0])
+        except Exception:
+            continue
+        if _pid_alive(pid):
+            continue
+        try:
+            st = json.loads(p.read_text())
+            rid = str(st.get("request_id") or "")
+            exp = st.get("expires_at")
+            live = True
+            if exp:
+                try:
+                    live = now <= datetime.fromisoformat(
+                        str(exp).replace("Z", "+00:00"))
+                except Exception:
+                    live = True
+        except Exception:
+            live, rid = False, ""
+        if not rid or not _REQUEST_ID_RE.match(rid):
+            _delete_marker(p, "confirm_claim_orphan_bad_dropped")
+            continue
+        target = PENDING_DIR / f"{rid}.json"
+        if live and not target.exists():
+            try:
+                os.replace(p, target)
+                _log({"event": "confirm_claim_orphan_restored",
+                      "request_id": rid, "dead_pid": pid})
+            except Exception as exc:
+                _log({"event": "confirm_claim_orphan_restore_failed",
+                      "request_id": rid,
+                      "error": f"{type(exc).__name__}: {exc}"})
+        else:
+            _delete_marker(p, "confirm_claim_orphan_expired_dropped",
+                           request_id=rid)
+
+
 def _load_pending_windows() -> list[dict]:
     """Read every marker in PENDING_DIR and enforce marker hygiene.
     Returns the list of live pending-confirm state dicts.
@@ -183,6 +247,7 @@ def _load_pending_windows() -> list[dict]:
     `.claimed.` files are in-flight spawns, not windows — skipped."""
     if not PENDING_DIR.exists():
         return []
+    _reap_orphaned_claims()
     now = datetime.now(timezone.utc)
     out = []
     for p in sorted(PENDING_DIR.iterdir()):
@@ -358,11 +423,14 @@ def _spawn_confirm(state: dict) -> bool:
             except Exception:
                 pass
     if spawn_ok:
-        try:
-            claimed.unlink()
-        except Exception as exc:
-            _log({"event": "confirm_claimed_cleanup_failed", "request_id": rid,
-                  "error": f"{type(exc).__name__}: {exc}"})
+        # Q3 (child-ack, 2026-07-08): do NOT delete the claim here. The old
+        # code consumed the operator's YES the instant Popen succeeded — a
+        # child that then crashed during bootstrap/import/request-load
+        # stranded a valid YES with nothing started. The claim now stays
+        # until the CHILD releases it right before consuming the token; a
+        # child that dies before that point leaves the claim for the reaper
+        # to restore, so the operator's next YES retries. Single-fire still
+        # holds: a concurrent YES skips `.claimed.` markers.
         return True
     # Spawn failed — put the marker back while the window is still live so
     # the operator's next YES can retry.

--- a/tools/hermes_hooks/u1_confirm_start/handler.py
+++ b/tools/hermes_hooks/u1_confirm_start/handler.py
@@ -45,10 +45,15 @@ Contract with u1_kit_workflow.py:
     also refuses — fail closed; the workflow warns at arm time when the
     binding config is missing, so this shows up before the YES, not at it.
   * Claim-then-spawn: the marker is atomically renamed to
-    <rid>.claimed.<pid>.json BEFORE spawning (of N concurrent YESes exactly
-    one wins the rename; the rest find nothing). Spawn success deletes the
-    claimed file; spawn failure renames it back while unexpired, so the
-    operator's next YES retries instead of the window dying silently.
+    <rid>.claimed.<claim_id>.json (an opaque per-spawn id) BEFORE spawning (of
+    N concurrent YESes exactly one wins the rename; the rest find nothing).
+    The spawned child is passed --confirm-claim-id and, at its commitment
+    point (right before it consumes the single-use token), releases ONLY its
+    own claim. The parent records the ACTUAL child pid into the claim content
+    so the reaper can tell a live confirm from a crashed one. Spawn failure
+    renames the claim back while unexpired, so the operator's next YES retries
+    instead of the window dying silently. A child that dies BEFORE its
+    commitment point leaves the claim for _reap_orphaned_claims to restore.
   * Expiry fails closed: expires_at missing -> marker deleted; unparseable
     or more than 24h out -> quarantined to <name>.bad (kept for
     inspection); expired -> deleted. All logged.
@@ -394,12 +399,14 @@ def _spawn_confirm(state: dict) -> bool:
     marker's only contribution is a request id that already matched
     _REQUEST_ID_RE in the loader (checked again for direct callers).
 
-    Claim = atomic rename to <rid>.claimed.<pid>.json: of N concurrent
-    YESes exactly one wins; the losers see FileNotFoundError and stand
-    down. Spawn success deletes the claimed file. Spawn failure renames it
-    back (while unexpired) so the next YES retries — the old unlink-then-
-    spawn burned the window when Popen failed. Returns True when the spawn
-    was issued."""
+    Claim = atomic rename to <rid>.claimed.<claim_id>.json (opaque per-spawn
+    id): of N concurrent YESes exactly one wins; the losers see
+    FileNotFoundError and stand down. On spawn success the claim is RETAINED
+    and annotated with the actual child pid; the child releases its own claim
+    at its commitment point, and the reaper restores it if the child dies
+    first. Spawn failure renames it back (while unexpired) so the next YES
+    retries — the old unlink-then-spawn burned the window when Popen failed.
+    Returns True when the spawn was issued."""
     rid = str(state.get("request_id") or "")
     src = state.get("_source_file")
     if not src or not _REQUEST_ID_RE.match(rid):
@@ -463,17 +470,31 @@ def _spawn_confirm(state: dict) -> bool:
         # holds: a concurrent YES skips `.claimed.` markers.
         #
         # Record the ACTUAL child pid + claim_id into the claim content so the
-        # reaper checks the CHILD's liveness, not the gateway's. Best-effort:
-        # if this write fails the reaper falls back to an mtime grace window.
+        # reaper checks the CHILD's liveness, not the gateway's.
+        #
+        # RACE (follow-up audit 2026-07-09): a fast child can reach its
+        # commitment point and DELETE this claim before we get here. We must
+        # NOT recreate a claim the child intentionally removed — doing so would
+        # let the reaper later "restore" a dead confirmation window. So open the
+        # EXISTING file read+write with NO create:
+        #   * already gone   -> FileNotFoundError -> child committed, do nothing;
+        #   * deleted mid-write -> our bytes land on the now-unlinked inode and
+        #     the claim is never resurrected (no path points at it).
         try:
-            _st = json.loads(claimed.read_text())
-        except Exception:
-            _st = dict(state)
-        _st["child_pid"] = child.pid if child is not None else None
-        _st["claim_id"] = claim_id
-        _st.setdefault("request_id", rid)
-        try:
-            claimed.write_text(json.dumps(_st))
+            with open(claimed, "r+") as _fh:
+                try:
+                    _st = json.loads(_fh.read() or "{}")
+                except Exception:
+                    _st = dict(state)
+                _st["child_pid"] = child.pid if child is not None else None
+                _st["claim_id"] = claim_id
+                _st.setdefault("request_id", rid)
+                _fh.seek(0)
+                _fh.truncate()
+                _fh.write(json.dumps(_st))
+        except FileNotFoundError:
+            _log({"event": "confirm_claim_released_before_pid_record",
+                  "request_id": rid})
         except Exception as exc:
             _log({"event": "confirm_claim_pid_record_failed", "request_id": rid,
                   "error": f"{type(exc).__name__}: {exc}"})

--- a/tools/hermes_hooks/u1_confirm_start/handler.py
+++ b/tools/hermes_hooks/u1_confirm_start/handler.py
@@ -68,6 +68,7 @@ import json
 import os
 import re
 import subprocess
+import uuid
 
 PENDING_DIR = Path(os.environ.get("U1_PENDING_CONFIRM_DIR",
                                   "/tmp/u1_pending_confirm"))
@@ -169,6 +170,11 @@ def _delete_marker(p: Path, event: str, **details) -> None:
               "error": f"{type(exc).__name__}: {exc}", **details})
 
 
+# A spawn that has claimed but not yet recorded its child pid is given
+# this long to finish before the reaper treats it as a failed spawn.
+_CLAIM_SPAWN_GRACE_S = 30.0
+
+
 def _pid_alive(pid: int) -> bool:
     try:
         os.kill(pid, 0)
@@ -182,39 +188,53 @@ def _pid_alive(pid: int) -> bool:
 
 
 def _reap_orphaned_claims() -> None:
-    """Restore a claim whose child died BEFORE releasing it (Q3, 2026-07-08).
+    """Restore a claim whose child died BEFORE releasing it (Q3, 2026-07-08;
+    pid source fixed in audit 2026-07-09).
 
-    A `<rid>.claimed.<pid>.json` still on disk with a DEAD pid means the child
-    crashed before it reached the token-consume point (where it removes its
-    own claim), so the operator's YES was never actually spent. Rename it back
-    to `<rid>.json` if the window is still live, else delete it. A live pid is
-    a confirm in flight — left alone."""
+    Liveness is the CHILD pid recorded in the claim CONTENT (`child_pid`) by
+    _spawn_confirm — NOT a pid parsed from the filename (the name now carries an
+    opaque claim_id). The old code parsed os.getpid() = the gateway pid, always
+    alive, so it never reaped. A dead child_pid means the child crashed before
+    its commitment point; restore `<rid>.json` if the window is still live, else
+    drop. A live child_pid is a confirm in flight — left alone. A claim with no
+    child_pid yet is a spawn still recording; it gets a short mtime grace before
+    being treated as a failed-spawn orphan."""
     if not PENDING_DIR.exists():
         return
     now = datetime.now(timezone.utc)
+    now_ts = now.timestamp()
     for p in list(PENDING_DIR.iterdir()):
         if not p.is_file() or ".claimed." not in p.name:
             continue
-        # filename: <rid>.claimed.<pid>.json
-        try:
-            pid = int(p.name.rsplit(".claimed.", 1)[1].split(".")[0])
-        except Exception:
-            continue
-        if _pid_alive(pid):
-            continue
         try:
             st = json.loads(p.read_text())
-            rid = str(st.get("request_id") or "")
-            exp = st.get("expires_at")
-            live = True
-            if exp:
-                try:
-                    live = now <= datetime.fromisoformat(
-                        str(exp).replace("Z", "+00:00"))
-                except Exception:
-                    live = True
         except Exception:
-            live, rid = False, ""
+            st = {}
+        rid = str(st.get("request_id") or "")
+        child_pid = st.get("child_pid")
+        if child_pid is None:
+            # spawn hasn't recorded the child pid yet (or died before it could).
+            try:
+                age = now_ts - p.stat().st_mtime
+            except Exception:
+                age = 0.0
+            if age < _CLAIM_SPAWN_GRACE_S:
+                continue  # genuinely in flight — leave it
+            # stale + no pid -> the recording never happened -> orphan.
+        else:
+            try:
+                if _pid_alive(int(child_pid)):
+                    continue  # child running -> in flight
+            except Exception:
+                continue  # unparseable pid -> do not reap on uncertainty
+        exp = st.get("expires_at")
+        live = True
+        if exp:
+            try:
+                live = now <= datetime.fromisoformat(
+                    str(exp).replace("Z", "+00:00"))
+            except Exception:
+                live = True
         if not rid or not _REQUEST_ID_RE.match(rid):
             _delete_marker(p, "confirm_claim_orphan_bad_dropped")
             continue
@@ -223,7 +243,7 @@ def _reap_orphaned_claims() -> None:
             try:
                 os.replace(p, target)
                 _log({"event": "confirm_claim_orphan_restored",
-                      "request_id": rid, "dead_pid": pid})
+                      "request_id": rid, "dead_child_pid": child_pid})
             except Exception as exc:
                 _log({"event": "confirm_claim_orphan_restore_failed",
                       "request_id": rid,
@@ -385,7 +405,13 @@ def _spawn_confirm(state: dict) -> bool:
     if not src or not _REQUEST_ID_RE.match(rid):
         return False
     src_path = Path(src)
-    claimed = src_path.with_name(f"{rid}.claimed.{os.getpid()}.json")
+    # Q3 fix (audit 2026-07-09): the claim filename carries an opaque claim_id,
+    # NOT os.getpid(). The old name embedded the GATEWAY pid (this hook runs in
+    # the gateway), so the reaper's liveness check always saw a live process
+    # and never restored an orphaned claim. Liveness now lives in the claim
+    # CONTENT as the actual spawned child pid (recorded below).
+    claim_id = uuid.uuid4().hex[:12]
+    claimed = src_path.with_name(f"{rid}.claimed.{claim_id}.json")
     try:
         os.rename(src_path, claimed)
     except FileNotFoundError:
@@ -394,17 +420,21 @@ def _spawn_confirm(state: dict) -> bool:
         _log({"event": "confirm_marker_claim_failed", "request_id": rid,
               "error": f"{type(exc).__name__}: {exc}"})
         return False
-    cmd = ["python3", WORKFLOW_PY, "--confirm-start-for", rid, "--json-events"]
+    # The child releases ONLY this claim_id at its commitment point (audit #3),
+    # so a concurrently re-armed generation's claim is never deleted.
+    cmd = ["python3", WORKFLOW_PY, "--confirm-start-for", rid,
+           "--confirm-claim-id", claim_id, "--json-events"]
     # Log path is DERIVED, never read from the marker.
     log_path = Path(f"/tmp/u1_confirm_start_{rid}.log")
     out = None
     spawn_ok = False
+    child = None
     try:
         try:
             out = open(log_path, "ab")
         except Exception:
             out = None  # losing the log is acceptable; losing the start isn't
-        subprocess.Popen(
+        child = subprocess.Popen(
             cmd,
             stdout=out if out is not None else subprocess.DEVNULL,
             stderr=subprocess.STDOUT,
@@ -431,6 +461,22 @@ def _spawn_confirm(state: dict) -> bool:
         # child that dies before that point leaves the claim for the reaper
         # to restore, so the operator's next YES retries. Single-fire still
         # holds: a concurrent YES skips `.claimed.` markers.
+        #
+        # Record the ACTUAL child pid + claim_id into the claim content so the
+        # reaper checks the CHILD's liveness, not the gateway's. Best-effort:
+        # if this write fails the reaper falls back to an mtime grace window.
+        try:
+            _st = json.loads(claimed.read_text())
+        except Exception:
+            _st = dict(state)
+        _st["child_pid"] = child.pid if child is not None else None
+        _st["claim_id"] = claim_id
+        _st.setdefault("request_id", rid)
+        try:
+            claimed.write_text(json.dumps(_st))
+        except Exception as exc:
+            _log({"event": "confirm_claim_pid_record_failed", "request_id": rid,
+                  "error": f"{type(exc).__name__}: {exc}"})
         return True
     # Spawn failed — put the marker back while the window is still live so
     # the operator's next YES can retry.


### PR DESCRIPTION
Safety hardening for the print-start path from two rounds of independent cold-review. See the v2.3.1 release notes for the operator-facing summary.

All four review conditions met; 886 tests pass; live-validated end to end.