### PR TITLE
v2.3.2: reliable cancel button

### DIFF
--- a/adapters/hermes/plugin/__init__.py
+++ b/adapters/hermes/plugin/__init__.py
@@ -204,7 +204,25 @@ def _pre_gateway_dispatch(**kwargs: Any) -> None:
         for platform_key, adapter in dict(adapters).items():
             name = str(getattr(platform_key, "value", platform_key)).lower()
             if "telegram" in name:
-                telegram_patch.ensure_patched(type(adapter))
+                if telegram_patch.ensure_patched(type(adapter)):
+                    # Register the callback handlers (form + grace-cancel button)
+                    # on the LIVE PTB app NOW, every inbound message — not lazily
+                    # on the first send_form. The countdown CANCEL button
+                    # (u1c:<rid>) rides the same pattern-scoped handler; a reprint
+                    # never sends a form, so before this the button had no handler
+                    # and taps were silently dropped (live 2026-07-09: a reprint
+                    # countdown CANCEL flashed, the grace expired, and the print
+                    # started anyway). _ensure_cb_handler is idempotent per-app
+                    # and re-registers on reconnect, so calling it per message is
+                    # cheap and guarantees the abort button is live before any
+                    # countdown.
+                    _reg = getattr(adapter, "_u1_ensure_cb_handler", None)
+                    if _reg is not None:
+                        try:
+                            _reg()
+                        except Exception:
+                            logger.warning("u1-form: proactive callback-handler "
+                                           "registration failed", exc_info=True)
     except Exception:
         logger.warning("u1-form: pre_gateway_dispatch patch attempt failed",
                        exc_info=True)

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -493,6 +493,72 @@ def test_plugin_registers_form_tool_and_dispatch_hook(monkeypatch, tmp_path):
     assert [h for h, _ in ctx.hooks] == ["pre_gateway_dispatch"]
 
 
+# --------------------------------------------------------------------------- #
+# Grace-window CANCEL button handler must be registered from an inbound
+# message, NOT only as a side effect of send_form. A reprint never sends a
+# form, so before this fix its countdown CANCEL button had no callback handler
+# and taps were silently dropped (live 2026-07-09: reprint cancel flashed, the
+# 120s grace expired, the print started anyway).
+# --------------------------------------------------------------------------- #
+
+def _patch_ensure(monkeypatch):
+    """Isolate the dispatch hook from the real (PTB-dependent) patcher: force
+    ensure_patched True so we can assert the hook proactively drives per-instance
+    handler registration."""
+    tp = importlib.import_module("hermes_plugins.u1_form.telegram_patch")
+    monkeypatch.setattr(tp, "ensure_patched", lambda cls: True)
+    return tp
+
+
+def test_pre_dispatch_registers_cancel_handler_every_message(monkeypatch, tmp_path):
+    mod = _load_plugin_pkg(monkeypatch, tmp_path)
+    _patch_ensure(monkeypatch)
+    calls = []
+
+    class _Adapter:
+        def _u1_ensure_cb_handler(self):
+            calls.append("reg")
+
+    class _Gw:
+        adapters = {"telegram": _Adapter()}
+
+    mod._pre_gateway_dispatch(gateway=_Gw(), event=None)
+    assert calls == ["reg"], (
+        "pre_gateway_dispatch must register the form + grace-cancel callback "
+        "handler on every inbound message (a reprint sends no form)")
+
+
+def test_pre_dispatch_skips_non_telegram_adapters(monkeypatch, tmp_path):
+    mod = _load_plugin_pkg(monkeypatch, tmp_path)
+    _patch_ensure(monkeypatch)
+    calls = []
+
+    class _Adapter:
+        def _u1_ensure_cb_handler(self):
+            calls.append("reg")
+
+    class _Gw:
+        adapters = {"discord": _Adapter()}
+
+    mod._pre_gateway_dispatch(gateway=_Gw(), event=None)
+    assert calls == [], "only the telegram adapter carries the U1 patch"
+
+
+def test_pre_dispatch_survives_registration_error(monkeypatch, tmp_path):
+    """A failure registering the handler must never break message dispatch."""
+    mod = _load_plugin_pkg(monkeypatch, tmp_path)
+    _patch_ensure(monkeypatch)
+
+    class _Adapter:
+        def _u1_ensure_cb_handler(self):
+            raise RuntimeError("app not ready")
+
+    class _Gw:
+        adapters = {"telegram": _Adapter()}
+
+    assert mod._pre_gateway_dispatch(gateway=_Gw(), event=None) is None
+
+
 def _fake_form_gateway(monkeypatch):
     """Stand-in for tools.form_gateway with the callback registry surface."""
     fg = types.ModuleType("tools.form_gateway")


### PR DESCRIPTION
Register the grace-window CANCEL button handler on every inbound message so it is live before any countdown, including reprints (which never send a form). Verified live: a reprint countdown CANCEL now aborts cleanly.