### PR TITLE
v2.4.0: reliable card attachments + reprint cancel fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,12 +305,25 @@ hermes skills install bbolinger/snapmaker-u1-toolkit/skills/3d-printer-slicing-a
 # 2. Deploy the workflow scripts to the runtime paths the skill calls into
 bash deploy_to_runtime.sh
 
-# 3. Install BOTH gateway hooks (the operator YES that starts a print and
+# 3. Install the plugins into Hermes: the u1-form tool plus the snapmaker_u1
+#    hook plugin (auto-skill load, next-action guard, and the image /
+#    review-doc attachment injector), and patch the gateway. Add
+#    --venv <path> if your Hermes venv is not /opt/hermes/.venv.
+python3 adapters/hermes/install.py
+
+# 4. Install BOTH gateway hooks (the operator YES that starts a print and
 #    the reply/tap CANCEL that stops one), restart the gateway, verify
 bash tools/install_hermes_u1_hooks.sh
 hermes gateway restart
 bash tools/install_hermes_u1_hooks.sh --verify
 ```
+
+Step 3 installs two plugins: the `u1-form` tool plugin and the `snapmaker_u1`
+hook plugin (a pip entry point, editable so `git pull` updates it). Restarting
+the gateway loads both; a fresh message logs
+`u1-form: TelegramAdapter.send_form installed`, and the attachment injector's
+hook comes up with the other `snapmaker_u1` hooks. Without step 3 the form,
+the auto-skill trigger, and the image/review-doc attachments do not load.
 
 The YES/CANCEL hooks bind to one operator in one private Telegram DM. With a
 single user id in `TELEGRAM_ALLOWED_USERS` the binding resolves itself;

--- a/README.md
+++ b/README.md
@@ -294,36 +294,50 @@ contract (every event the workflow + audit log emit, with payload shapes), see
 
 ## Hermes integration
 
-Hermes typically ships `numpy` + `Pillow` in its bundled venv (verify:
-`/opt/hermes/.venv/bin/python -c 'import numpy, PIL; print("ok")'` — the
-toolkit's interpreter auto-detection finds it). Then:
+**Install on Linux.** The deploy scripts are bash and `install.py` targets a
+Linux venv (`bin/`, `lib/pythonX.Y/`). Run it inside the Hermes container, on a
+Linux host, or under WSL / Git Bash on Windows — not raw Windows `cmd`. Hermes
+typically ships `numpy` + `Pillow` in its bundled venv (verify:
+`/opt/hermes/.venv/bin/python -c 'import numpy, PIL; print("ok")'`).
+
+Run each step and let it finish before the next. Step 1 asks a `y/N` you have to
+answer, so do not paste the whole block at once.
+
+**1. Install the bundled skill** (answer `y` at the prompt):
 
 ```bash
-# 1. Install the bundled skill
 hermes skills install bbolinger/snapmaker-u1-toolkit/skills/3d-printer-slicing-automation
+```
 
-# 2. Deploy the workflow scripts to the runtime paths the skill calls into
+**2. Deploy the workflow scripts** to the runtime paths the skill calls into:
+
+```bash
 bash deploy_to_runtime.sh
+```
 
-# 3. Install the plugins into Hermes: the u1-form tool plus the snapmaker_u1
-#    hook plugin (auto-skill load, next-action guard, and the image /
-#    review-doc attachment injector), and patch the gateway. Add
-#    --venv <path> if your Hermes venv is not /opt/hermes/.venv.
+**3. Install both Hermes plugins and patch the gateway.** This installs the
+`u1-form` tool plugin and the `snapmaker_u1` hook plugin (auto-skill load,
+next-action guard, and the image / review-doc attachment injector). Add
+`--venv <path>` if your Hermes venv is not `/opt/hermes/.venv`:
+
+```bash
 python3 adapters/hermes/install.py
+```
 
-# 4. Install BOTH gateway hooks (the operator YES that starts a print and
-#    the reply/tap CANCEL that stops one), restart the gateway, verify
+`install.py` loads two plugins: `u1-form` and `snapmaker_u1` (a pip entry point,
+installed editable so `git pull` updates it). Without this step the form, the
+auto-skill trigger, and the image/review-doc attachments do not load. Watch for
+its `[4/6] install the snapmaker_u1 hook plugin` and a `[6/6]` verify ending
+`OK: hooks=...transform_llm_output`.
+
+**4. Install both gateway hooks** (the operator YES that starts a print and the
+reply/tap CANCEL that stops one), restart the gateway, and verify:
+
+```bash
 bash tools/install_hermes_u1_hooks.sh
 hermes gateway restart
 bash tools/install_hermes_u1_hooks.sh --verify
 ```
-
-Step 3 installs two plugins: the `u1-form` tool plugin and the `snapmaker_u1`
-hook plugin (a pip entry point, editable so `git pull` updates it). Restarting
-the gateway loads both; a fresh message logs
-`u1-form: TelegramAdapter.send_form installed`, and the attachment injector's
-hook comes up with the other `snapmaker_u1` hooks. Without step 3 the form,
-the auto-skill trigger, and the image/review-doc attachments do not load.
 
 The YES/CANCEL hooks bind to one operator in one private Telegram DM. With a
 single user id in `TELEGRAM_ALLOWED_USERS` the binding resolves itself;

--- a/README.md
+++ b/README.md
@@ -235,6 +235,11 @@ python3 scripts/u1_slice_workflow.py --help
 python3 scripts/snapmaker_u1_status.py
 ```
 
+The networked steps (`extract_profiles_from_printer.py`, `snapmaker_u1_status.py`)
+time out until `SNAPMAKER_U1_HOST` points at your printer's real LAN IP. The
+`.env.example` default `192.168.1.100` is only a placeholder, so edit `.env`
+first, or skip those two until the printer is reachable.
+
 On Windows (PowerShell) the same steps apply with `Copy-Item .env.example .env`
 and backslash paths; the data dir defaults to
 `C:\Users\<you>\.local\share\snapmaker-u1` (override with
@@ -338,6 +343,11 @@ bash tools/install_hermes_u1_hooks.sh
 hermes gateway restart
 bash tools/install_hermes_u1_hooks.sh --verify
 ```
+
+If you run these from inside a Hermes Desktop or gateway chat, run `hermes
+gateway restart` from a **separate** terminal outside Hermes. The gateway
+refuses to restart itself from within its own process (it would kill the command
+mid-run), so the hooks stay unloaded until you restart it externally.
 
 The YES/CANCEL hooks bind to one operator in one private Telegram DM. With a
 single user id in `TELEGRAM_ALLOWED_USERS` the binding resolves itself;

--- a/adapters/hermes/install.py
+++ b/adapters/hermes/install.py
@@ -301,6 +301,58 @@ def _verify(venv_python: Path, tools_dir: Path) -> str:
     return proc.stdout.strip()
 
 
+def _install_hook_plugin(venv_python: Path, plugin_pkg: Path, *,
+                         dry_run: bool) -> str:
+    """pip-install the ``snapmaker_u1`` entry-point plugin into the Hermes venv.
+
+    This is a DIFFERENT plugin from the u1-form one deployed above: it carries
+    the pip ``hermes_agent.plugins`` entry point that registers the auto-skill
+    loader, the next-action directive, and the v2.4 transform_llm_output image /
+    review-doc attach hook. Because it is an entry-point plugin, pip-installing
+    it is all Hermes needs to discover and load it (no ``plugins enable`` step).
+    Editable (-e) so a later ``git pull`` in the clone takes effect without a
+    reinstall."""
+    if not (plugin_pkg / "pyproject.toml").is_file():
+        return f"SKIPPED: no plugin package at {plugin_pkg}"
+    cmd = [str(venv_python), "-m", "pip", "install", "-e", str(plugin_pkg)]
+    if dry_run:
+        return "would run: " + " ".join(cmd)
+    try:
+        proc = subprocess.run(cmd, text=True, capture_output=True, timeout=300)
+    except Exception as exc:  # noqa: BLE001 - surface any launch failure
+        return f"FAILED to launch pip: {exc}"
+    if proc.returncode != 0:
+        return f"FAILED (rc={proc.returncode}): {proc.stderr.strip()[:400]}"
+    return "installed (editable)"
+
+
+def _verify_hook_plugin(venv_python: Path) -> str:
+    """Confirm the snapmaker_u1 plugin loads in the venv and registers all three
+    hooks -- in particular transform_llm_output, without which v2.4 image and
+    review-doc delivery silently does nothing."""
+    src = (
+        "import logging; logging.disable(logging.CRITICAL)\n"
+        "class C:\n"
+        "    def __init__(s): s.h=[]\n"
+        "    def register_hook(s,n,cb): s.h.append(n)\n"
+        "    def register_skill(s,*a,**k): pass\n"
+        "import importlib\n"
+        "m=importlib.import_module('snapmaker_u1')\n"
+        "c=C(); m.register(c)\n"
+        "need={'pre_gateway_dispatch','transform_tool_result','transform_llm_output'}\n"
+        "miss=need-set(c.h)\n"
+        "print('OK: hooks='+','.join(c.h)) if not miss "
+        "else print('MISSING hooks: '+','.join(sorted(miss)))\n"
+    )
+    try:
+        proc = subprocess.run([str(venv_python), "-c", src], text=True,
+                              capture_output=True, timeout=60)
+    except Exception as exc:  # noqa: BLE001
+        return f"verify FAILED to launch: {exc}"
+    return (proc.stdout or proc.stderr or
+            f"no output (rc={proc.returncode})").strip()
+
+
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(description="Install the u1 form flow into Hermes.")
     ap.add_argument("--venv", type=Path, default=Path("/opt/hermes/.venv"),
@@ -328,6 +380,10 @@ def main(argv=None) -> int:
     here = Path(__file__).resolve().parent
     plugin_src = here / "plugin"
     plugin_dst = _plugin_dir_dest()
+    # The pip entry-point plugin (auto-skill loader + next-action guard + the
+    # v2.4 attachment injector) lives at <repo>/plugin, two levels up from
+    # adapters/hermes/.
+    hook_plugin_src = here.parent.parent / "plugin"
     # u1_form_telegram.py (the L1 pure renderer) is single-sourced from the
     # sibling adapters/telegram/ directory — the hermes tree carries no copy.
     renderer_src = here.parent / "telegram" / "u1_form_telegram.py"
@@ -356,6 +412,17 @@ def main(argv=None) -> int:
                 shutil.rmtree(plugin_dst)
                 print(f"removed       {plugin_dst}")
         print(f"plugin disable: {_disable_plugin(venv, dry_run=a.dry_run)}")
+        # Remove the pip entry-point plugin too (best-effort).
+        _uni = [str(venv_python), "-m", "pip", "uninstall", "-y",
+                "snapmaker-u1-toolkit-plugin"]
+        if a.dry_run:
+            print("would run: " + " ".join(_uni))
+        else:
+            try:
+                _p = subprocess.run(_uni, text=True, capture_output=True, timeout=120)
+                print(f"hook plugin pip uninstall: rc={_p.returncode}")
+            except Exception as _exc:  # noqa: BLE001
+                print(f"hook plugin pip uninstall failed to launch: {_exc}")
         bak = run_py.with_suffix(run_py.suffix + ".u1-bak")
         # Only restore the backup when OUR patch is actually present in the
         # current run.py. If Hermes was upgraded since install, pip replaced
@@ -390,7 +457,7 @@ def main(argv=None) -> int:
         print("       before copying anything — no files were modified.")
         return 2
 
-    print("[1/5] copy tools/ (form_gateway) + remove pre-plugin layout files")
+    print("[1/6] copy tools/ (form_gateway) + remove pre-plugin layout files")
     for name, src in tools_src.items():
         if not src.exists():
             raise SystemExit(f"source missing: {src}")
@@ -411,7 +478,7 @@ def main(argv=None) -> int:
                 print(f"  removed   {tgt} (superseded by the plugin)")
 
     print()
-    print(f"[2/5] deploy plugin -> {plugin_dst}")
+    print(f"[2/6] deploy plugin -> {plugin_dst}")
     plugin_files = {name: plugin_src / name for name in PLUGIN_FILES}
     plugin_files["u1_form_telegram.py"] = renderer_src
     for name, src in plugin_files.items():
@@ -426,11 +493,15 @@ def main(argv=None) -> int:
             print(f"  {'copied   ' if changed else 'unchanged '} {tgt}")
 
     print()
-    print("[3/5] enable plugin (user plugins are opt-in)")
+    print("[3/6] enable plugin (user plugins are opt-in)")
     print(f"  {_enable_plugin(venv, dry_run=a.dry_run)}")
 
     print()
-    print("[4/5] patch gateway/run.py (anchor-based, marker-guarded)")
+    print("[4/6] install the snapmaker_u1 hook plugin (pip entry point)")
+    print(f"  {_install_hook_plugin(venv_python, hook_plugin_src, dry_run=a.dry_run)}")
+
+    print()
+    print("[5/6] patch gateway/run.py (anchor-based, marker-guarded)")
     status = _patch_run_py(run_py, dry_run=a.dry_run)
     print(f"  {status}: {run_py}")
     if status == "anchor-not-found":
@@ -453,11 +524,12 @@ def main(argv=None) -> int:
         return 0
 
     print()
-    print("[5/5] verify: bare-composite toolset resolution (clarify held + form offered)")
+    print("[6/6] verify: toolset resolution + hook-plugin registration")
     print(" ", _verify(venv_python, tools_dir))
+    print(" ", _verify_hook_plugin(venv_python))
 
     print()
-    print("Done. Restart the Hermes gateway so the plugin loads and the patched")
+    print("Done. Restart the Hermes gateway so both plugins load and the patched")
     print("gateway/run.py takes effect. First inbound Telegram message installs")
     print("send_form on the live adapter class (watch for the")
     print("'u1-form: TelegramAdapter.send_form installed' log line).")

--- a/adapters/hermes/tools/u1_kit_tool.py
+++ b/adapters/hermes/tools/u1_kit_tool.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""
+u1_kit Tool — slice a multi-part 3D-print kit (.zip of STLs) for Snapmaker U1.
+
+The OUTER tool for kit prints. The LLM picks this ONCE when the operator
+supplies a kit zip; everything downstream — form rendering, answer
+collection, re-invocation, readiness card — happens deterministically inside
+this handler.
+
+This is the deterministic-dispatch counterpart to ``tools/terminal_tool.py``
+calling ``approval_callback`` when ``detect_dangerous_command`` fires. The
+LLM doesn't have to pick ``form`` or relay the kit_form event — the u1_kit
+handler does it itself, via the same ``form_gateway`` session-keyed notify
+mechanism the rest of Hermes uses (see adapters/hermes/README.md for the
+verified 8-piece pattern).
+
+Flow:
+  1. LLM calls ``u1_kit(model_path="...")``.
+  2. Handler invokes ``u1_kit_workflow.py --json-events`` as a subprocess.
+  3. Parses the ``kit_form`` event (need_input) from its stdout, extracts
+     ``form_schema`` + ``request_id``.
+  4. Calls ``form_gateway.invoke_form(session_key, form_schema)`` — blocks
+     until the operator submits via Telegram inline buttons (or the text
+     fallback). The platform send + user-tap routing all happen via the
+     monkey-patched ``TelegramAdapter.send_form`` / ``_handle_callback_query``.
+  5. Re-invokes the workflow with ``--form-answers-json <answer>
+     --request-id <id>``.
+  6. Returns the ``kit_readiness_card`` (request_id, plate count, gated
+     plate, Stage 1 command) to the LLM.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from gateway.session_context import get_session_env  # type: ignore
+from tools import form_gateway  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+# Path to the kit workflow inside the Hermes container. The snapmaker-u1
+# toolkit is deployed at /opt/data/scripts/ by deploy_to_runtime.sh.
+DEFAULT_WORKFLOW_SCRIPT = os.environ.get(
+    "U1_KIT_WORKFLOW", "/opt/data/scripts/u1_kit_workflow.py")
+DEFAULT_PYTHON = os.environ.get("U1_KIT_PYTHON", "python3")
+
+# 25 min covers a slow multi-plate slice; analysis phase is seconds.
+SUBPROCESS_TIMEOUT_SEC = int(os.environ.get("U1_KIT_TIMEOUT_SEC", "1500"))
+
+
+def _run_workflow(args: List[str], *, timeout: float) -> Dict[str, Any]:
+    """Run u1_kit_workflow.py with --json-events; collect events + stderr.
+
+    The workflow exits naturally at phase boundaries (after kit_form in the
+    analyze phase, after kit_readiness_card in the slice phase), so a simple
+    communicate() is enough — no need to stream while it runs.
+    """
+    try:
+        proc = subprocess.run(
+            args, capture_output=True, text=True, timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return {"_error": f"u1_kit_workflow timed out after {timeout:.0f}s"}
+    except FileNotFoundError as exc:
+        return {"_error": f"u1_kit_workflow not found: {exc}"}
+
+    events: List[Dict[str, Any]] = []
+    for line in (proc.stdout or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+            if isinstance(ev, dict):
+                events.append(ev)
+        except json.JSONDecodeError:
+            # Workflow occasionally emits a non-event indented summary line.
+            pass
+    return {
+        "returncode": proc.returncode,
+        "events": events,
+        "stderr": (proc.stderr or "").strip(),
+    }
+
+
+def _find_event(events: List[Dict[str, Any]], stage: str,
+                key: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    for ev in events:
+        if ev.get("stage") != stage:
+            continue
+        if key is not None and ev.get("key") != key:
+            continue
+        return ev
+    return None
+
+
+def u1_kit_tool(
+    model_path: str,
+    *,
+    request_id: Optional[str] = None,
+    workflow_script: str = DEFAULT_WORKFLOW_SCRIPT,
+    python: str = DEFAULT_PYTHON,
+    timeout: float = SUBPROCESS_TIMEOUT_SEC,
+) -> str:
+    """LLM-facing handler — returns a JSON string with phase + payload."""
+    if not model_path or not isinstance(model_path, str):
+        return json.dumps({"error": "model_path is required"}, ensure_ascii=False)
+    path = Path(model_path).expanduser()
+    try:
+        path = path.resolve()
+    except OSError as exc:
+        return json.dumps({"error": f"bad model_path: {exc}"}, ensure_ascii=False)
+    if not path.exists():
+        return json.dumps({"error": f"model not found: {path}"}, ensure_ascii=False)
+
+    session_key = get_session_env("HERMES_SESSION_KEY", "")
+    if not session_key:
+        return json.dumps(
+            {"error": "u1_kit requires a gateway session (no session_key in context)."},
+            ensure_ascii=False)
+    if form_gateway.get_notify(session_key) is None:
+        return json.dumps(
+            {"error": "form notify callback not registered for this session — "
+                      "run adapters/hermes/install.py to wire the patch, then restart Hermes."},
+            ensure_ascii=False)
+
+    # --- Phase 1: analyze + emit kit_form -----------------------------------
+    cmd1 = [python, workflow_script, str(path), "--json-events"]
+    if request_id:
+        cmd1 += ["--request-id", request_id]
+    logger.info("u1_kit phase 1: %s",
+                " ".join(shlex.quote(a) for a in cmd1))
+    res1 = _run_workflow(cmd1, timeout=timeout)
+    if "_error" in res1:
+        return json.dumps({"error": res1["_error"], "phase": "analysis"},
+                          ensure_ascii=False)
+    if res1.get("returncode", 0) != 0:
+        return json.dumps({
+            "phase": "analysis",
+            "error": f"u1_kit_workflow analysis failed (rc={res1['returncode']})",
+            "stderr": res1.get("stderr", "")[:2000],
+        }, ensure_ascii=False)
+
+    setup_required = _find_event(res1["events"], "setup_required")
+    if setup_required:
+        return json.dumps({
+            "phase": "setup_required",
+            "kind": setup_required.get("kind"),
+            "message": setup_required.get("message"),
+        }, ensure_ascii=False)
+
+    kit_form = _find_event(res1["events"], "need_input", key="kit_form")
+    if kit_form is None:
+        # No form needed — maybe a single-STL happy path or analysis-failed.
+        readiness = _find_event(res1["events"], "kit_readiness_card")
+        if readiness:
+            return json.dumps({"phase": "ready", "readiness_card": readiness},
+                              ensure_ascii=False)
+        return json.dumps({
+            "phase": "analysis",
+            "error": "no kit_form event emitted (and no readiness card)",
+            "events_tail": res1["events"][-5:],
+        }, ensure_ascii=False)
+
+    form_schema = kit_form.get("form_schema") or {}
+    wf_request_id = kit_form.get("request_id") or request_id
+    if not isinstance(form_schema, dict) or not form_schema.get("fields"):
+        return json.dumps({
+            "phase": "analysis",
+            "error": "kit_form event missing valid form_schema",
+            "kit_form": kit_form,
+        }, ensure_ascii=False)
+
+    # --- Phase 2: render the form natively, block on operator submit -------
+    answer = form_gateway.invoke_form(session_key, form_schema)
+    if not isinstance(answer, dict):
+        return json.dumps({
+            "phase": "form",
+            "error": "form_gateway.invoke_form returned non-dict",
+            "got": str(answer)[:200],
+            "request_id": wf_request_id,
+        }, ensure_ascii=False)
+    if answer.get("_error"):
+        return json.dumps({"phase": "form", "error": answer["_error"],
+                           "request_id": wf_request_id}, ensure_ascii=False)
+    if answer.get("_cancelled"):
+        return json.dumps({"phase": "cancelled", "request_id": wf_request_id},
+                          ensure_ascii=False)
+    if answer.get("_timeout"):
+        return json.dumps({"phase": "form_timeout", "request_id": wf_request_id},
+                          ensure_ascii=False)
+
+    # --- Phase 3: re-invoke workflow with the answer ------------------------
+    cmd2 = [
+        python, workflow_script, str(path), "--json-events",
+        "--request-id", str(wf_request_id),
+        "--form-answers-json", json.dumps(answer, ensure_ascii=False),
+    ]
+    logger.info("u1_kit phase 3: %s",
+                " ".join(shlex.quote(a) for a in cmd2))
+    res2 = _run_workflow(cmd2, timeout=timeout)
+    if "_error" in res2:
+        return json.dumps({"error": res2["_error"], "phase": "slice",
+                           "request_id": wf_request_id}, ensure_ascii=False)
+    if res2.get("returncode", 0) != 0:
+        return json.dumps({
+            "phase": "slice",
+            "error": f"u1_kit_workflow slice failed (rc={res2['returncode']})",
+            "stderr": res2.get("stderr", "")[:2000],
+            "request_id": wf_request_id,
+        }, ensure_ascii=False)
+
+    rejected = _find_event(res2["events"], "form_rejected")
+    if rejected:
+        return json.dumps({
+            "phase": "form_rejected",
+            "request_id": wf_request_id,
+            "errors": rejected.get("errors", []),
+            "user_message": ("Form answer didn't validate. Re-call u1_kit "
+                             "(same request_id will resume) to try again."),
+        }, ensure_ascii=False)
+
+    readiness = _find_event(res2["events"], "kit_readiness_card")
+    if readiness is None:
+        return json.dumps({
+            "phase": "slice",
+            "error": "no readiness card emitted",
+            "request_id": wf_request_id,
+            "events_tail": res2["events"][-5:],
+        }, ensure_ascii=False)
+
+    return json.dumps({
+        "phase": "ready",
+        "request_id": wf_request_id,
+        "readiness_card": readiness,
+        "user_answer": answer,
+    }, ensure_ascii=False)
+
+
+def check_u1_kit_requirements() -> bool:
+    """u1_kit needs the workflow script at the expected deploy path."""
+    return Path(DEFAULT_WORKFLOW_SCRIPT).exists()
+
+
+# =============================================================================
+# Function-calling tool schema
+# =============================================================================
+
+U1_KIT_SCHEMA = {
+    "name": "u1_kit",
+    "description": (
+        "Slice a multi-part 3D PRINT KIT (a .zip of STLs intended to print "
+        "together) for the Snapmaker U1 3D printer.\n\n"
+        "Call this ONCE when the operator supplies a kit zip — everything "
+        "after (form rendering with native inline buttons, operator answer "
+        "collection, slice, readiness card) happens deterministically inside "
+        "this tool. The native form is shown automatically; do NOT also "
+        "call the `form` tool yourself.\n\n"
+        "Returns a JSON object with `phase` and (on success) a "
+        "`readiness_card` containing the request_id, plate count, gated "
+        "plate filename, and the Stage-1 photo-gate command for plate 1."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "model_path": {
+                "type": "string",
+                "description": (
+                    "Absolute path to the kit .zip on the Hermes filesystem "
+                    "(e.g. an attachment saved to /tmp/parts.zip)."
+                ),
+            },
+            "request_id": {
+                "type": "string",
+                "description": (
+                    "Optional explicit request id to resume a prior kit "
+                    "session. Usually omit — the workflow content-hashes "
+                    "the archive bytes to resume automatically."
+                ),
+            },
+        },
+        "required": ["model_path"],
+    },
+}
+
+
+# --- Registry ----------------------------------------------------------------
+from tools.registry import registry  # type: ignore
+
+registry.register(
+    name="u1_kit",
+    toolset="u1_kit",
+    schema=U1_KIT_SCHEMA,
+    handler=lambda args, **_kw: u1_kit_tool(
+        model_path=args.get("model_path", ""),
+        request_id=args.get("request_id") or None,
+    ),
+    check_fn=check_u1_kit_requirements,
+    emoji="🖨️",
+)

--- a/plugin/plugin.yaml
+++ b/plugin/plugin.yaml
@@ -4,5 +4,6 @@ description: Auto-trigger the Snapmaker U1 slicing skill on STL/3MF/ZIP attachme
 provides_hooks:
   - pre_gateway_dispatch
   - transform_tool_result
+  - transform_llm_output
 provides_skills:
   - 3d-printer-slicing-automation

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "snapmaker-u1-toolkit-plugin"
-version = "0.1.0"
+version = "0.2.0"
 description = "Hermes plugin: auto-trigger the snapmaker U1 3D-printer-slicing skill on STL/3MF/ZIP attachments. Wraps the existing snapmaker-u1-toolkit skill + scripts."
 license = {text = "MIT"}
 requires-python = ">=3.11"

--- a/plugin/src/snapmaker_u1/__init__.py
+++ b/plugin/src/snapmaker_u1/__init__.py
@@ -114,3 +114,16 @@ def register(ctx: Any) -> None:
         "snapmaker_u1 plugin: transform_tool_result hook registered "
         "(next_action_required directive)",
     )
+
+    # Register the transform_llm_output hook that attaches U1 images
+    # structurally instead of relying on the model echoing their paths. The
+    # workflow arms a per-session marker when it emits an image-bearing card;
+    # this hook injects the authoritative paths into the outbound reply so core
+    # attaches the real images even when the model mangles or omits the paths
+    # (observed live on reprint 2026-07-09: bed photo shown as raw text).
+    from .hooks.attachment_injector import transform as attachment_injector_transform
+    ctx.register_hook("transform_llm_output", attachment_injector_transform)
+    logger.info(
+        "snapmaker_u1 plugin: transform_llm_output hook registered "
+        "(structural U1 image attachment)",
+    )

--- a/plugin/src/snapmaker_u1/hooks/attachment_injector.py
+++ b/plugin/src/snapmaker_u1/hooks/attachment_injector.py
@@ -117,8 +117,17 @@ def _load_and_consume_marker() -> dict[str, Any] | None:
     return data
 
 
-def _looks_like_u1_image(token: str) -> bool:
+def _is_u1_artifact_path(token: str) -> bool:
     low = token.lower()
+    # Any token that references a U1 request path is ours to remove, even when
+    # the model splits or corrupts it. Gemma has been seen to jam a space and a
+    # '$' into the path ("requests/ $u1_..._8dfe85/bed_snapshot.jpg", live
+    # 2026-07-09), which whitespace-splits into a bare "/snapmaker_u1/requests/"
+    # prefix plus a "$..._8dfe85/bed_snapshot.jpg" tail. Catch BOTH: any token
+    # holding the request-path fragment, plus any image-extension token with a
+    # U1 filename signature. Neither should survive into the visible reply.
+    if "/snapmaker_u1/requests" in low or "snapmaker_u1/requests" in low:
+        return True
     if not low.endswith(_IMAGE_EXTS):
         return False
     return any(sig in low for sig in _U1_SIGNATURES)
@@ -132,7 +141,7 @@ def _strip_echoed_u1_images(text: str) -> str:
         return text
     out_lines: list[str] = []
     for line in text.splitlines():
-        kept = [tok for tok in line.split() if not _looks_like_u1_image(tok)]
+        kept = [tok for tok in line.split() if not _is_u1_artifact_path(tok)]
         # A line that was ONLY a path (or several) collapses to empty; drop it.
         # A line with prose plus a trailing path keeps the prose.
         if not line.split():

--- a/plugin/src/snapmaker_u1/hooks/attachment_injector.py
+++ b/plugin/src/snapmaker_u1/hooks/attachment_injector.py
@@ -141,14 +141,21 @@ def _strip_echoed_u1_images(text: str) -> str:
         return text
     out_lines: list[str] = []
     for line in text.splitlines():
-        kept = [tok for tok in line.split() if not _is_u1_artifact_path(tok)]
+        toks = line.split()
+        removed = any(_is_u1_artifact_path(t) for t in toks)
+        kept = [t for t in toks if not _is_u1_artifact_path(t)]
+        if removed:
+            # When we pulled a U1 path off a line, drop an orphaned "MEDIA:"
+            # directive keyword it was riding on (the model wraps the review doc
+            # as "MEDIA: <path>"; without this the bare "MEDIA:" would leak).
+            kept = [t for t in kept if t.upper() != "MEDIA:"]
         # A line that was ONLY a path (or several) collapses to empty; drop it.
         # A line with prose plus a trailing path keeps the prose.
-        if not line.split():
+        if not toks:
             out_lines.append(line)
         elif kept:
             out_lines.append(" ".join(kept))
-        # else: line was purely image path(s) -> omit entirely
+        # else: line was purely path(s)/MEDIA: -> omit entirely
     cleaned = "\n".join(out_lines)
     # Collapse 3+ newlines left by removed blocks down to a paragraph break.
     cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
@@ -157,7 +164,15 @@ def _strip_echoed_u1_images(text: str) -> str:
 
 def transform(response_text: str = "", session_id: str = "", model: str = "",
               platform: str = "", **kwargs: Any) -> Any:
-    """Inject authoritative U1 image paths so core attaches the real images.
+    """Inject authoritative U1 attachment paths so core delivers the real files.
+
+    The marker carries images (plate preview / isometric / bed snapshot) and
+    documents (the review doc). Both are injected as BARE paths: core's
+    extract_local_files sends image extensions as native photos and everything
+    else (the .md review doc) through send_document. A .md can only ride the
+    bare-path route -- the MEDIA: directive has an extension allowlist that
+    excludes it -- which is why the model echoing "MEDIA: ...review.md" never
+    delivered the doc.
 
     Returns a replacement string, or None to leave the reply unchanged.
     """
@@ -166,41 +181,44 @@ def transform(response_text: str = "", session_id: str = "", model: str = "",
         if not marker:
             return None  # no U1 card this turn -> no-op
 
-        # Keep only images that actually exist on disk right now.
-        images: list[str] = []
-        for p in marker.get("images", []) or []:
+        # Authoritative attachments = images + documents, in that order, keeping
+        # only what exists on disk right now.
+        paths: list[str] = []
+        for p in ((marker.get("images", []) or [])
+                  + (marker.get("documents", []) or [])):
             try:
-                if p and Path(p).is_file() and p not in images:
-                    images.append(str(p))
+                if p and Path(p).is_file() and p not in paths:
+                    paths.append(str(p))
             except OSError:
                 continue
 
         cleaned = _strip_echoed_u1_images(response_text or "")
 
-        if not images:
+        if not paths:
             # Marker existed but nothing survives on disk. Return the cleaned
             # text only if we actually removed a dead/mangled path AND something
             # is left to send. A bare "" would be treated by turn_finalizer as
             # "leave unchanged" (falsy), so never return that.
             if cleaned and cleaned != (response_text or "").strip():
-                logger.info("snapmaker_u1 attachment_injector: no live images; "
+                logger.info("snapmaker_u1 attachment_injector: no live files; "
                             "stripped echoed path(s) from reply "
                             "(request_id=%s)", marker.get("request_id"))
                 return cleaned
             return None
 
         # Append the real paths as bare lines. Core's extract_local_files will
-        # attach each as a native photo and remove the line from the visible
-        # text, so the operator sees the card text plus the images, never a path.
+        # deliver each (photo for images, document for the review .md) and remove
+        # the line from the visible text, so the operator sees the card text plus
+        # the attachments, never a path.
         body = cleaned.rstrip()
-        new_text = (body + "\n\n" if body else "") + "\n".join(images)
+        new_text = (body + "\n\n" if body else "") + "\n".join(paths)
         logger.info(
             "snapmaker_u1 attachment_injector: injected %d authoritative "
-            "image path(s) (request_id=%s), replacing model-echoed paths",
-            len(images), marker.get("request_id"),
+            "file path(s) (request_id=%s), replacing model-echoed paths",
+            len(paths), marker.get("request_id"),
         )
         return new_text
-    except Exception as exc:  # never break the operator's reply over an image
+    except Exception as exc:  # never break the operator's reply over an attachment
         logger.warning("snapmaker_u1 attachment_injector: failed, leaving reply "
                        "unchanged: %s", exc)
         return None

--- a/plugin/src/snapmaker_u1/hooks/attachment_injector.py
+++ b/plugin/src/snapmaker_u1/hooks/attachment_injector.py
@@ -1,0 +1,197 @@
+"""transform_llm_output hook — attach U1 images structurally, not by model echo.
+
+The problem this closes
+-----------------------
+Hermes core (gateway/platforms/base.py) delivers images by scanning the agent's
+FINAL reply text for bare local file paths and turning any that exist on disk
+into native Telegram photos (extract_local_files / extract_images strip the path
+from the visible text and send it as media). The U1 readiness / bed-clear /
+reprint card therefore depended on gemma4 echoing the workflow's image paths
+verbatim. Observed live 2026-07-09 (reprint): the model rebuilt the paths from
+a mangled request_id (`u1_2026...` became `u2026...`), so the paths pointed at
+nothing, nothing attached, and the operator saw the bed photo and previews as
+raw text. Losing the bed photo means losing the visual bed-clear check.
+
+The fix (same model-free philosophy as the YES boundary)
+--------------------------------------------------------
+The workflow OWNS the real image paths in the request dir. When it emits an
+image-bearing card it drops a one-shot marker keyed by ``HERMES_SESSION_KEY``
+(the workflow subprocess inherits it; the gateway process where this hook runs
+sets it at run.py's dispatch, so both sides read the identical value). This hook
+reads that marker on the outbound turn and:
+
+  1. strips any U1 image path the model echoed (correct OR mangled) so a dead
+     path can never leak into the visible reply, then
+  2. appends the AUTHORITATIVE paths (that actually exist on disk) as bare
+     lines, so core attaches the true images regardless of what the model typed.
+
+The marker is consumed one-shot. The safety gate is untouched — it validates
+real gcode, never an image.
+
+Contract (agent/turn_finalizer.py): the hook is called with
+``response_text``, ``session_id``, ``model``, ``platform``; returning a non-empty
+string replaces the reply, first hook to return one wins. Any failure here MUST
+degrade to leaving the reply unchanged (return None) — an attachment is never
+worth breaking the operator's message.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Marker location + schema. Mirrors the workflow's _arm_pending_attach in
+# scripts/u1_kit_workflow.py (kept in lockstep by these two comments, the same
+# way the pending_confirm marker is shared with the u1_confirm_start hook).
+#   dir     : $U1_PENDING_ATTACH_DIR (default /tmp/u1_pending_attach)
+#   file    : sha256(HERMES_SESSION_KEY)[:16].json
+#   content : {"request_id": str, "images": [abs path, ...],
+#              "operator": str|None, "created_at": float}
+_PENDING_ATTACH_DIR = Path(
+    os.environ.get("U1_PENDING_ATTACH_DIR", "/tmp/u1_pending_attach"))
+# Images are only relevant to the immediate reply; a marker older than this is
+# stale (a crash or a non-card turn) and is discarded rather than re-attached.
+_PENDING_ATTACH_TTL_S = 120.0
+
+_IMAGE_EXTS = (".png", ".jpg", ".jpeg", ".webp")
+
+# A whitespace-delimited token "looks like a U1 image path" when it ends in an
+# image extension AND carries a U1 signature. This strips both the correct paths
+# and the mangled ones (e.g. a corrupted request id) so neither survives as text.
+# Signatures are kept specific to U1 artifacts so an unrelated image path the
+# model might mention (e.g. /photos/sunset_preview.png) is left alone. The real
+# U1 images are plate_<n>_preview.png / plate_<n>_iso.png / bed_snapshot.jpg /
+# parts_thumbnails.png, all of which carry "plate_", "bed_snapshot" or
+# "parts_thumbnail", and every one lives under a "snapmaker_u1"/"/requests/"
+# path, so a generic "_preview"/"_iso" substring is deliberately NOT a signature.
+_U1_SIGNATURES = (
+    "snapmaker_u1", "/requests/", "plate_", "bed_snapshot", "parts_thumbnail",
+)
+
+
+def _marker_path_for_session() -> Path | None:
+    key = os.environ.get("HERMES_SESSION_KEY", "")
+    # Empty key still hashes deterministically; on a single-operator U1 install
+    # that simply means one shared slot, which is correct (one operator).
+    digest = hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
+    return _PENDING_ATTACH_DIR / f"{digest}.json"
+
+
+def _load_and_consume_marker() -> dict[str, Any] | None:
+    """Return the marker for this session and delete it (one-shot). None if
+    absent or stale. Never raises."""
+    path = _marker_path_for_session()
+    if path is None:
+        return None
+    try:
+        raw = path.read_text()
+    except FileNotFoundError:
+        return None
+    except OSError:
+        return None
+    # Consume immediately so a half-processed / stale marker can't be re-used
+    # on a later turn.
+    try:
+        path.unlink()
+    except OSError:
+        pass
+    try:
+        data = json.loads(raw or "{}")
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    created = data.get("created_at")
+    if isinstance(created, (int, float)) and (time.time() - created) > _PENDING_ATTACH_TTL_S:
+        logger.info("snapmaker_u1 attachment_injector: discarding stale marker "
+                    "(age %.0fs > %.0fs)", time.time() - created, _PENDING_ATTACH_TTL_S)
+        return None
+    return data
+
+
+def _looks_like_u1_image(token: str) -> bool:
+    low = token.lower()
+    if not low.endswith(_IMAGE_EXTS):
+        return False
+    return any(sig in low for sig in _U1_SIGNATURES)
+
+
+def _strip_echoed_u1_images(text: str) -> str:
+    """Remove any U1 image path the model wrote, correct or mangled. Operates on
+    whitespace tokens so a path on its own line is removed cleanly; collapses the
+    blank lines that leaves behind."""
+    if not text:
+        return text
+    out_lines: list[str] = []
+    for line in text.splitlines():
+        kept = [tok for tok in line.split() if not _looks_like_u1_image(tok)]
+        # A line that was ONLY a path (or several) collapses to empty; drop it.
+        # A line with prose plus a trailing path keeps the prose.
+        if not line.split():
+            out_lines.append(line)
+        elif kept:
+            out_lines.append(" ".join(kept))
+        # else: line was purely image path(s) -> omit entirely
+    cleaned = "\n".join(out_lines)
+    # Collapse 3+ newlines left by removed blocks down to a paragraph break.
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.strip()
+
+
+def transform(response_text: str = "", session_id: str = "", model: str = "",
+              platform: str = "", **kwargs: Any) -> Any:
+    """Inject authoritative U1 image paths so core attaches the real images.
+
+    Returns a replacement string, or None to leave the reply unchanged.
+    """
+    try:
+        marker = _load_and_consume_marker()
+        if not marker:
+            return None  # no U1 card this turn -> no-op
+
+        # Keep only images that actually exist on disk right now.
+        images: list[str] = []
+        for p in marker.get("images", []) or []:
+            try:
+                if p and Path(p).is_file() and p not in images:
+                    images.append(str(p))
+            except OSError:
+                continue
+
+        cleaned = _strip_echoed_u1_images(response_text or "")
+
+        if not images:
+            # Marker existed but nothing survives on disk. Return the cleaned
+            # text only if we actually removed a dead/mangled path AND something
+            # is left to send. A bare "" would be treated by turn_finalizer as
+            # "leave unchanged" (falsy), so never return that.
+            if cleaned and cleaned != (response_text or "").strip():
+                logger.info("snapmaker_u1 attachment_injector: no live images; "
+                            "stripped echoed path(s) from reply "
+                            "(request_id=%s)", marker.get("request_id"))
+                return cleaned
+            return None
+
+        # Append the real paths as bare lines. Core's extract_local_files will
+        # attach each as a native photo and remove the line from the visible
+        # text, so the operator sees the card text plus the images, never a path.
+        body = cleaned.rstrip()
+        new_text = (body + "\n\n" if body else "") + "\n".join(images)
+        logger.info(
+            "snapmaker_u1 attachment_injector: injected %d authoritative "
+            "image path(s) (request_id=%s), replacing model-echoed paths",
+            len(images), marker.get("request_id"),
+        )
+        return new_text
+    except Exception as exc:  # never break the operator's reply over an image
+        logger.warning("snapmaker_u1 attachment_injector: failed, leaving reply "
+                       "unchanged: %s", exc)
+        return None

--- a/plugin/src/snapmaker_u1/hooks/attachment_injector.py
+++ b/plugin/src/snapmaker_u1/hooks/attachment_injector.py
@@ -40,9 +40,11 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import math
 import os
 import re
 import time
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -60,8 +62,29 @@ _PENDING_ATTACH_DIR = Path(
 # Images are only relevant to the immediate reply; a marker older than this is
 # stale (a crash or a non-card turn) and is discarded rather than re-attached.
 _PENDING_ATTACH_TTL_S = 120.0
+# Allow a little clock slack for a marker stamped microseconds in the "future".
+_CLOCK_SKEW_S = 60.0
 
 _IMAGE_EXTS = (".png", ".jpg", ".jpeg", ".webp")
+
+# The marker file is writable by anything running as the same uid, so its paths
+# are NOT trusted. Before handing a path to core (which will send it to the
+# operator), it must resolve to a real, non-symlink file that is a KNOWN U1
+# artifact by name, sitting in a request-id directory under the canonical
+# requests root. Audit 2026-07-10: a forged marker injected "/etc/hosts" and the
+# hook would have delivered it. We validate the destination, not the marker.
+_REQUESTS_ROOT = Path(
+    os.environ.get("SNAPMAKER_U1_DATA_DIR", "/opt/data/snapmaker_u1")) / "requests"
+# Exact artifact basenames the workflow ever emits (plate N preview/isometric,
+# the fresh bed snapshot, the parts grid, and the review doc). Nothing else.
+_ALLOWED_ARTIFACT_RE = re.compile(
+    r"^(?:plate_\d+_preview\.png|plate_\d+_iso\.png|bed_snapshot\.jpg|"
+    r"parts_thumbnails\.png|review\.md)$")
+# A request-id directory name (the immediate parent of an artifact). Reprints
+# reuse the ORIGINAL request's artifacts, so the parent is not necessarily the
+# marker's own request_id -- any valid request dir under the root is acceptable,
+# which is why we match the shape rather than the exact id.
+_REQUEST_ID_RE = re.compile(r"^u1_\d{4}_\d{4}_[a-z0-9]+$")
 
 # A whitespace-delimited token "looks like a U1 image path" when it ends in an
 # image extension AND carries a U1 signature. This strips both the correct paths
@@ -79,40 +102,58 @@ _U1_SIGNATURES = (
 
 def _marker_path_for_session() -> Path | None:
     key = os.environ.get("HERMES_SESSION_KEY", "")
-    # Empty key still hashes deterministically; on a single-operator U1 install
-    # that simply means one shared slot, which is correct (one operator).
+    if not key:
+        # Refuse the empty-key shared slot: without a stable per-session key,
+        # every session hashes to the same file and one request's marker could
+        # be redeemed by an unrelated turn (audit #3). No key -> no marker.
+        return None
     digest = hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
     return _PENDING_ATTACH_DIR / f"{digest}.json"
 
 
 def _load_and_consume_marker() -> dict[str, Any] | None:
-    """Return the marker for this session and delete it (one-shot). None if
-    absent or stale. Never raises."""
+    """Atomically claim the marker for this session and return it, or None.
+
+    Single-use is enforced by an atomic rename to a unique name: only the caller
+    whose ``os.rename`` wins may read it, so two concurrent finalizers cannot
+    both consume the same marker (audit #4 -- read-then-unlink let both win).
+    Never raises."""
     path = _marker_path_for_session()
     if path is None:
         return None
+    claimed = path.with_name(path.name + f".claimed.{uuid.uuid4().hex[:8]}")
     try:
-        raw = path.read_text()
-    except FileNotFoundError:
+        os.rename(path, claimed)  # atomic on POSIX; loser gets FileNotFoundError
+    except (FileNotFoundError, OSError):
         return None
-    except OSError:
-        return None
-    # Consume immediately so a half-processed / stale marker can't be re-used
-    # on a later turn.
     try:
-        path.unlink()
+        raw = claimed.read_text()
     except OSError:
-        pass
+        raw = ""
+    finally:
+        try:
+            claimed.unlink()
+        except OSError:
+            pass
     try:
         data = json.loads(raw or "{}")
     except (ValueError, TypeError):
         return None
     if not isinstance(data, dict):
         return None
+    # created_at must be a finite number in a sane window. A missing or string
+    # timestamp previously skipped the TTL check entirely and was accepted as
+    # fresh (audit #6); bool is an int subclass, so exclude it explicitly.
     created = data.get("created_at")
-    if isinstance(created, (int, float)) and (time.time() - created) > _PENDING_ATTACH_TTL_S:
-        logger.info("snapmaker_u1 attachment_injector: discarding stale marker "
-                    "(age %.0fs > %.0fs)", time.time() - created, _PENDING_ATTACH_TTL_S)
+    if (not isinstance(created, (int, float)) or isinstance(created, bool)
+            or not math.isfinite(created)):
+        logger.info("snapmaker_u1 attachment_injector: rejecting marker with "
+                    "missing/malformed created_at")
+        return None
+    age = time.time() - created
+    if age > _PENDING_ATTACH_TTL_S or age < -_CLOCK_SKEW_S:
+        logger.info("snapmaker_u1 attachment_injector: discarding stale/future "
+                    "marker (age %.0fs)", age)
         return None
     return data
 
@@ -162,6 +203,30 @@ def _strip_echoed_u1_images(text: str) -> str:
     return cleaned.strip()
 
 
+def _is_safe_artifact(path_str: str) -> bool:
+    """True only for a real, non-symlink file that is a known U1 artifact by name,
+    inside a request-id directory under the canonical requests root.
+
+    The marker is same-uid-writable and therefore untrusted; this is what stops a
+    forged marker turning the hook into a "send any readable local file" primitive
+    (audit #2). resolve(strict=True) follows every symlink, so a symlinked
+    component pointing outside the root is caught by the final under-root check."""
+    try:
+        p = Path(path_str)
+        if p.is_symlink():
+            return False
+        rp = p.resolve(strict=True)
+        if not rp.is_file():
+            return False
+        if not _ALLOWED_ARTIFACT_RE.match(rp.name):
+            return False
+        if not _REQUEST_ID_RE.match(rp.parent.name):
+            return False
+        return _REQUESTS_ROOT.resolve() in rp.parents
+    except (OSError, ValueError, RuntimeError):
+        return False
+
+
 def transform(response_text: str = "", session_id: str = "", model: str = "",
               platform: str = "", **kwargs: Any) -> Any:
     """Inject authoritative U1 attachment paths so core delivers the real files.
@@ -181,16 +246,22 @@ def transform(response_text: str = "", session_id: str = "", model: str = "",
         if not marker:
             return None  # no U1 card this turn -> no-op
 
-        # Authoritative attachments = images + documents, in that order, keeping
-        # only what exists on disk right now.
+        # Authoritative attachments = images + documents, in that order. Every
+        # path is validated (real, non-symlink, known artifact name, under the
+        # requests root) because the marker is untrusted (audit #2). Anything
+        # else is dropped and logged, never delivered.
         paths: list[str] = []
         for p in ((marker.get("images", []) or [])
                   + (marker.get("documents", []) or [])):
-            try:
-                if p and Path(p).is_file() and p not in paths:
-                    paths.append(str(p))
-            except OSError:
+            sp = str(p) if p else ""
+            if not sp or sp in paths:
                 continue
+            if _is_safe_artifact(sp):
+                paths.append(sp)
+            else:
+                logger.warning("snapmaker_u1 attachment_injector: refusing path "
+                               "that is not a known U1 artifact under the "
+                               "requests root: %r", sp)
 
         cleaned = _strip_echoed_u1_images(response_text or "")
 

--- a/scripts/u1_kit_workflow.py
+++ b/scripts/u1_kit_workflow.py
@@ -3255,7 +3255,11 @@ def _emit_confirm_card(args, operator: str, archive: Path, kit: dict[str, Any],
             _attach_images.append(preview_result["iso_path"])
     if bed_result["ok"]:
         _attach_images.append(bed_result["snapshot_path"])
-    _arm_pending_attach(request_id, _attach_images, operator)
+    _attach_docs = ([review_doc_path]
+                    if (review_doc_path and Path(review_doc_path).is_file())
+                    else [])
+    _arm_pending_attach(request_id, _attach_images, operator,
+                        documents=_attach_docs)
 
     _emit(events_file, {
         "stage": "need_input",
@@ -3483,16 +3487,21 @@ _PENDING_ATTACH_DIR = Path(os.environ.get("U1_PENDING_ATTACH_DIR",
 
 def _arm_pending_attach(request_id: str, images: "list[str] | None",
                         operator: "str | None",
+                        documents: "list[str] | None" = None,
                         session_key: "str | None" = None) -> None:
     """Drop the one-shot marker the attachment_injector hook redeems on the next
     outbound turn. ``images`` are absolute paths in the request dir (plate
-    preview, isometric, bed snapshot). No-op when there's nothing to attach.
+    preview, isometric, bed snapshot); ``documents`` are non-image files to
+    deliver as attachments (the review .md, which core sends via send_document
+    only from a bare path, never a MEDIA: directive). No-op when there's nothing
+    to attach.
 
     Best-effort: an attachment is never worth failing the card or the safety
     gate over, so every error is swallowed."""
     import hashlib
     imgs = [str(p) for p in (images or []) if p]
-    if not imgs:
+    docs = [str(p) for p in (documents or []) if p]
+    if not imgs and not docs:
         return
     key = session_key if session_key is not None else os.environ.get("HERMES_SESSION_KEY", "")
     try:
@@ -3502,6 +3511,7 @@ def _arm_pending_attach(request_id: str, images: "list[str] | None",
         payload = {
             "request_id": request_id,
             "images": imgs,
+            "documents": docs,
             "operator": operator,
             "created_at": time.time(),
         }
@@ -4036,7 +4046,10 @@ def _action_reprint_start(events_file: Path | None, json_events: bool,
     for _p in (_art_preview, _art_iso, bed.get("snapshot_path")):
         if _p and Path(_p).is_file():
             _reprint_attach.append(_p)
-    _arm_pending_attach(new_rid, _reprint_attach, operator)
+    _reprint_docs = ([_art_review]
+                     if (_art_review and Path(_art_review).is_file()) else [])
+    _arm_pending_attach(new_rid, _reprint_attach, operator,
+                        documents=_reprint_docs)
 
     # This turn IS the operator's review moment (original previews + review
     # doc + fresh bed photo, above). Record it with the same revision+hash

--- a/scripts/u1_kit_workflow.py
+++ b/scripts/u1_kit_workflow.py
@@ -3504,6 +3504,11 @@ def _arm_pending_attach(request_id: str, images: "list[str] | None",
     if not imgs and not docs:
         return
     key = session_key if session_key is not None else os.environ.get("HERMES_SESSION_KEY", "")
+    if not key:
+        # No stable per-session key -> don't write the shared empty-key slot,
+        # which an unrelated turn could redeem (audit #3). The hook refuses the
+        # empty-key slot on read too; keep both ends aligned.
+        return
     try:
         _PENDING_ATTACH_DIR.mkdir(parents=True, exist_ok=True)
         digest = hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]

--- a/scripts/u1_kit_workflow.py
+++ b/scripts/u1_kit_workflow.py
@@ -3243,6 +3243,20 @@ def _emit_confirm_card(args, operator: str, archive: Path, kit: dict[str, Any],
                             "kind": "bed_snapshot",
                             "image": bed_result["snapshot_path"]}, json_events)
 
+    # Arm the structural-attachment marker with the SAME image paths the render
+    # events carry, so the transform_llm_output hook attaches them regardless of
+    # whether the model echoes them (v2.4 — kills the reprint bed-photo-as-text
+    # bug observed 2026-07-09). Normal and reprint both reach this card via
+    # _action_start, so this one site covers both.
+    _attach_images: list[str] = []
+    if preview_result and preview_result.get("ok"):
+        _attach_images.append(preview_result["path"])
+        if preview_result.get("iso_path"):
+            _attach_images.append(preview_result["iso_path"])
+    if bed_result["ok"]:
+        _attach_images.append(bed_result["snapshot_path"])
+    _arm_pending_attach(request_id, _attach_images, operator)
+
     _emit(events_file, {
         "stage": "need_input",
         "key": "confirm",
@@ -3450,6 +3464,52 @@ def _capture_bed_and_issue_token(out_dir: Path) -> dict[str, Any]:
             "approval_expires_at": expires_at,
             "captured_at_utc": captured_ts,
             "reason": None}
+
+
+# Structural image attachment (v2.4). Hermes core attaches images by scanning
+# the model's final reply for bare on-disk file paths. Relying on gemma to echo
+# the workflow's paths verbatim broke live on reprint (2026-07-09): a mangled
+# request_id pointed the paths at nothing, so the bed photo + previews rendered
+# as raw text and the operator lost the visual bed-clear check. The workflow
+# owns the real paths, so it arms this one-shot marker when it emits an
+# image-bearing card; the plugin's transform_llm_output hook
+# (snapmaker_u1.hooks.attachment_injector) injects the authoritative paths into
+# the outbound reply. Keyed by HERMES_SESSION_KEY, which the workflow subprocess
+# inherits from the gateway process the hook runs in, so both sides resolve the
+# same marker (same cross-process trick the pending_confirm marker uses).
+_PENDING_ATTACH_DIR = Path(os.environ.get("U1_PENDING_ATTACH_DIR",
+                                          "/tmp/u1_pending_attach"))
+
+
+def _arm_pending_attach(request_id: str, images: "list[str] | None",
+                        operator: "str | None",
+                        session_key: "str | None" = None) -> None:
+    """Drop the one-shot marker the attachment_injector hook redeems on the next
+    outbound turn. ``images`` are absolute paths in the request dir (plate
+    preview, isometric, bed snapshot). No-op when there's nothing to attach.
+
+    Best-effort: an attachment is never worth failing the card or the safety
+    gate over, so every error is swallowed."""
+    import hashlib
+    imgs = [str(p) for p in (images or []) if p]
+    if not imgs:
+        return
+    key = session_key if session_key is not None else os.environ.get("HERMES_SESSION_KEY", "")
+    try:
+        _PENDING_ATTACH_DIR.mkdir(parents=True, exist_ok=True)
+        digest = hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
+        target = _PENDING_ATTACH_DIR / f"{digest}.json"
+        payload = {
+            "request_id": request_id,
+            "images": imgs,
+            "operator": operator,
+            "created_at": time.time(),
+        }
+        tmp = target.with_name(target.name + ".tmp")
+        tmp.write_text(json.dumps(payload))
+        os.replace(tmp, target)  # atomic publish
+    except Exception:
+        pass
 
 
 # Model-free YES (post-incident 2026-07-07): the agent model fired the

--- a/scripts/u1_kit_workflow.py
+++ b/scripts/u1_kit_workflow.py
@@ -4026,6 +4026,18 @@ def _action_reprint_start(events_file: Path | None, json_events: bool,
                             "instruction": "Surface this fresh bed photo path BARE in your reply."},
               json_events)
 
+    # Arm the structural-attachment marker for the reprint card (v2.4). The
+    # reprint path emits its images as render events above and asks the model to
+    # echo the paths, which is the fragile bit that showed the bed photo as text
+    # on 2026-07-09. Arm the same paths here so the transform_llm_output hook
+    # attaches them regardless of what the model echoes. This is the reprint
+    # sibling of the arm in _emit_confirm_card (reprints never reach that path).
+    _reprint_attach: list[str] = []
+    for _p in (_art_preview, _art_iso, bed.get("snapshot_path")):
+        if _p and Path(_p).is_file():
+            _reprint_attach.append(_p)
+    _arm_pending_attach(new_rid, _reprint_attach, operator)
+
     # This turn IS the operator's review moment (original previews + review
     # doc + fresh bed photo, above). Record it with the same revision+hash
     # binding a kit readiness card carries — can_start() drift-checks the

--- a/scripts/u1_kit_workflow.py
+++ b/scripts/u1_kit_workflow.py
@@ -45,7 +45,7 @@ from pathlib import Path
 def _check_python_has_deps(python_path: str, deps: tuple = ("numpy", "PIL")) -> bool:
     try:
         proc = subprocess.run(
-            [python_path, "-c", f"import {', '.join(deps)}"],
+            [python_path, "-c", "import numpy; from PIL import Image, ImageDraw"],
             capture_output=True, text=True, timeout=10,
         )
         return proc.returncode == 0
@@ -54,18 +54,27 @@ def _check_python_has_deps(python_path: str, deps: tuple = ("numpy", "PIL")) -> 
 
 
 def _ensure_compat_python() -> None:
+    # Import the COMPILED Pillow entry (Image/ImageDraw), not just the `PIL`
+    # package: a mismatched interpreter can import bare PIL yet fail to load the
+    # _imaging C extension, so `import PIL` alone passes a broken install (live
+    # on Windows Hermes Desktop where PYTHONPATH pointed 3.13 at a 3.11 venv,
+    # install report 2026-07-10). Catch broad exceptions, since a broken
+    # extension can surface as more than ImportError.
     try:
         import numpy  # noqa: F401
-        import PIL    # noqa: F401
+        from PIL import Image, ImageDraw  # noqa: F401
         return
-    except ImportError:
+    except Exception:
         pass
     missing = []
-    for dep in ("numpy", "PIL"):
-        try:
-            __import__(dep)
-        except ImportError:
-            missing.append("pillow" if dep == "PIL" else dep)
+    try:
+        import numpy  # noqa: F401
+    except Exception:
+        missing.append("numpy")
+    try:
+        from PIL import Image, ImageDraw  # noqa: F401
+    except Exception:
+        missing.append("pillow")
     here = Path(__file__).resolve().parent
     root = here.parent
     candidates: list[str] = []

--- a/scripts/u1_slice_workflow.py
+++ b/scripts/u1_slice_workflow.py
@@ -26,7 +26,7 @@ def _check_python_has_deps(python_path: str, deps: tuple = ('numpy', 'PIL')) -> 
     """Return True iff `python_path` can import every dep without error."""
     try:
         proc = subprocess.run(
-            [python_path, '-c', f'import {", ".join(deps)}'],
+            [python_path, '-c', 'import numpy; from PIL import Image, ImageDraw'],
             capture_output=True, text=True, timeout=10,
         )
         return proc.returncode == 0
@@ -38,21 +38,30 @@ def _ensure_compat_python() -> None:
     """If the current interpreter lacks numpy/PIL, find a known-good Python
     that has them and re-exec self with it. Exit with a clear error if none
     of the candidates work."""
-    # Fast path: current interpreter has the deps
+    # Fast path: current interpreter has the deps. Import the COMPILED Pillow
+    # entry (Image/ImageDraw), not just the `PIL` package -- a mismatched
+    # interpreter can import bare PIL yet fail to load the _imaging C extension,
+    # so `import PIL` alone passes a broken install (live on Windows Hermes
+    # Desktop with a 3.13/3.11 PYTHONPATH mix, install report 2026-07-10). Catch
+    # broad exceptions, since a broken extension can surface as more than
+    # ImportError.
     try:
         import numpy  # noqa: F401
-        import PIL    # noqa: F401
+        from PIL import Image, ImageDraw  # noqa: F401
         return
-    except ImportError:
+    except Exception:
         pass
 
     # Identify which deps are actually missing (for the error message)
     missing = []
-    for dep in ('numpy', 'PIL'):
-        try:
-            __import__(dep)
-        except ImportError:
-            missing.append('pillow' if dep == 'PIL' else dep)
+    try:
+        import numpy  # noqa: F401
+    except Exception:
+        missing.append('numpy')
+    try:
+        from PIL import Image, ImageDraw  # noqa: F401
+    except Exception:
+        missing.append('pillow')
 
     # Candidate Python paths, in priority order. The U1_TOOLKIT_PYTHON env
     # var wins so users can override on any host without code changes.

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -917,15 +917,26 @@ def test_install_copies_deploys_plugin_patches_and_verifies(tmp_path, monkeypatc
     bak = run_py.with_suffix(run_py.suffix + ".u1-bak")
     assert bak.read_text() == _STOCK_RUN_PY
 
-    # enable + verify both ran: `hermes plugins enable u1-form`, then the
-    # bare-composite invariant check with syntactically valid source.
-    assert len(calls) == 2
+    # Four subprocess steps now run, in order: enable u1-form, pip-install the
+    # snapmaker_u1 hook plugin, the bare-composite toolset invariant verify, and
+    # the hook-plugin registration verify.
+    assert len(calls) == 4
     assert calls[0][:4] == [str(venv / "bin" / "hermes"), "plugins", "enable", "u1-form"]
+    # pip install -e <repo>/plugin
     assert calls[1][0] == str(venv / "bin" / "python3")
-    assert calls[1][1] == "-c"
-    compile(calls[1][2], "<verify-src>", "exec")
-    assert "'clarify' in ts" in calls[1][2]  # the eviction regression check
-    assert "'form' in ts" in calls[1][2]
+    assert calls[1][1:5] == ["-m", "pip", "install", "-e"]
+    assert calls[1][5].endswith("/plugin")
+    # bare-composite invariant check with syntactically valid source
+    assert calls[2][0] == str(venv / "bin" / "python3")
+    assert calls[2][1] == "-c"
+    compile(calls[2][2], "<verify-src>", "exec")
+    assert "'clarify' in ts" in calls[2][2]  # the eviction regression check
+    assert "'form' in ts" in calls[2][2]
+    # hook-plugin registration verify must assert transform_llm_output loads
+    assert calls[3][0] == str(venv / "bin" / "python3")
+    assert calls[3][1] == "-c"
+    compile(calls[3][2], "<hook-verify-src>", "exec")
+    assert "transform_llm_output" in calls[3][2]
 
 
 def test_install_patched_run_py_body_is_valid_python(tmp_path, monkeypatch):

--- a/tests/test_attachment_injector.py
+++ b/tests/test_attachment_injector.py
@@ -73,6 +73,27 @@ def test_roundtrip_strips_mangled_path_and_attaches_real_ones(attach_dir, tmp_pa
     assert not list(attach_dir.iterdir()), "marker must be consumed"
 
 
+def test_space_dollar_split_mangle_is_fully_stripped(attach_dir, tmp_path):
+    """The exact live 2026-07-09 reprint failure: gemma emitted
+    'requests/ $u1_..._8dfe85/bed_snapshot.jpg' which whitespace-splits into a
+    bare '/snapmaker_u1/requests/' prefix plus a '$..._8dfe85/bed_snapshot.jpg'
+    tail. Neither fragment may survive; the real bed photo is attached instead."""
+    bed = _png(tmp_path, "bed_snapshot.jpg")  # authoritative, in /tmp (no U1 dir sig)
+    wf._arm_pending_attach("u1_2026_0709_8dfe85", [bed], "brent")
+    reply = (
+        "2\n"
+        "/opt/data/snapmaker_u1/requests/ $u1_2026_0709_8dfe85/bed_snapshot.jpg\n"
+        "Sliced plate, review doc, and a fresh bed photo are attached. "
+        "Reply YES to start."
+    )
+    out = ai.transform(response_text=reply, session_id="s")
+    assert out is not None
+    assert bed in out, "real bed photo injected"
+    assert "$u1_2026_0709_8dfe85" not in out, "mangled tail stripped"
+    assert "snapmaker_u1/requests" not in out, "mangled dir prefix stripped too"
+    assert "Reply YES to start." in out, "prose kept"
+
+
 def test_correct_echo_is_not_doubled(attach_dir, tmp_path):
     preview = _png(tmp_path, "plate_1_preview.png")
     wf._arm_pending_attach("u1_2026_0709_abccb7", [preview], "op")

--- a/tests/test_attachment_injector.py
+++ b/tests/test_attachment_injector.py
@@ -1,0 +1,158 @@
+"""Tests for the v2.4 structural image attachment.
+
+The workflow (scripts/u1_kit_workflow.py `_arm_pending_attach`) and the plugin
+hook (plugin/src/snapmaker_u1/hooks/attachment_injector.py) are written
+independently and only meet through a marker file keyed by HERMES_SESSION_KEY.
+The load-bearing test is the round trip: what the writer drops, the reader picks
+up and turns into attached image paths, with the model's echoed paths (correct
+OR mangled) removed so exactly the real images attach.
+"""
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# The plugin isn't pip-installed in the test env; put its src on the path.
+_PLUGIN_SRC = Path(__file__).resolve().parent.parent / "plugin" / "src"
+sys.path.insert(0, str(_PLUGIN_SRC))
+
+from snapmaker_u1.hooks import attachment_injector as ai  # noqa: E402
+import u1_kit_workflow as wf  # scripts/ is on the path via conftest  # noqa: E402
+
+_SESSION_KEY = "telegram:987654:main"
+
+
+@pytest.fixture
+def attach_dir(tmp_path, monkeypatch):
+    """Point both the writer and the reader at the same throwaway marker dir and
+    pin a known session key."""
+    d = tmp_path / "pending_attach"
+    d.mkdir()
+    monkeypatch.setattr(ai, "_PENDING_ATTACH_DIR", d)
+    monkeypatch.setattr(wf, "_PENDING_ATTACH_DIR", d)
+    monkeypatch.setenv("HERMES_SESSION_KEY", _SESSION_KEY)
+    return d
+
+
+def _png(tmp_path, name):
+    p = tmp_path / name
+    p.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
+    return str(p)
+
+
+def test_no_marker_is_noop(attach_dir):
+    assert ai.transform(response_text="Reply YES to start.", session_id="s") is None
+
+
+def test_roundtrip_strips_mangled_path_and_attaches_real_ones(attach_dir, tmp_path):
+    preview = _png(tmp_path, "plate_1_preview.png")
+    bed = _png(tmp_path, "bed_snapshot.jpg")
+    # Writer side (what the workflow does at the readiness card).
+    wf._arm_pending_attach("u1_2026_0709_abccb7", [preview, bed], "op")
+    assert list(attach_dir.iterdir()), "marker should exist after arming"
+
+    # Model mangled the request id, so its echoed path points at nothing.
+    reply = (
+        "Here is your plate and the current bed.\n"
+        "/opt/data/snapmaker_u1/requests/u2026_bad/plate_1_preview.png\n"
+        "Reply YES to start the print."
+    )
+    out = ai.transform(response_text=reply, session_id="s")
+
+    assert out is not None
+    # Real paths injected...
+    assert preview in out and bed in out
+    # ...the mangled one is gone (won't leak as text).
+    assert "u2026_bad" not in out
+    # Prose is preserved.
+    assert "Reply YES to start the print." in out
+    # Marker consumed (one-shot).
+    assert not list(attach_dir.iterdir()), "marker must be consumed"
+
+
+def test_correct_echo_is_not_doubled(attach_dir, tmp_path):
+    preview = _png(tmp_path, "plate_1_preview.png")
+    wf._arm_pending_attach("u1_2026_0709_abccb7", [preview], "op")
+    # Model happened to echo the correct path this time.
+    reply = f"Plate ready.\n{preview}\nReply YES."
+    out = ai.transform(response_text=reply, session_id="s")
+    assert out is not None
+    assert out.count(preview) == 1, "authoritative path must appear exactly once"
+
+
+def test_inline_path_stripped_keeps_prose(attach_dir, tmp_path):
+    bed = _png(tmp_path, "bed_snapshot.jpg")
+    wf._arm_pending_attach("u1_2026_0709_abccb7", [bed], "op")
+    reply = f"Current bed photo {bed} looks clear."
+    out = ai.transform(response_text=reply, session_id="s")
+    assert out is not None
+    assert "looks clear." in out
+    # The inline path token is removed from the prose line, then re-appended bare.
+    assert out.rstrip().endswith(bed)
+
+
+def test_nonexistent_images_and_no_echo_is_noop(attach_dir, tmp_path):
+    missing = str(tmp_path / "gone" / "plate_1_preview.png")  # never created
+    wf._arm_pending_attach("u1_2026_0709_abccb7", [missing], "op")
+    reply = "Reply YES to start."
+    out = ai.transform(response_text=reply, session_id="s")
+    # Nothing exists to attach and nothing was echoed to strip -> leave reply be.
+    assert out is None
+    assert not list(attach_dir.iterdir()), "marker still consumed"
+
+
+def test_stale_marker_discarded(attach_dir, tmp_path):
+    preview = _png(tmp_path, "plate_1_preview.png")
+    # Hand-write a marker that is older than the TTL at the hashed path.
+    target = ai._marker_path_for_session()
+    target.write_text(json.dumps({
+        "request_id": "u1_2026_0709_old",
+        "images": [preview],
+        "operator": "op",
+        "created_at": time.time() - (ai._PENDING_ATTACH_TTL_S + 60),
+    }))
+    out = ai.transform(response_text="Reply YES.", session_id="s")
+    assert out is None, "a stale marker must not attach"
+    assert not target.exists(), "stale marker is still consumed"
+
+
+def test_keyed_by_session_key(attach_dir, tmp_path, monkeypatch):
+    preview = _png(tmp_path, "plate_1_preview.png")
+    # Arm under a DIFFERENT session key than the one the hook will read.
+    wf._arm_pending_attach("u1_2026_0709_abccb7", [preview], "op",
+                           session_key="telegram:OTHER:main")
+    out = ai.transform(response_text="Reply YES.", session_id="s")
+    assert out is None, "a marker for another session must not be picked up"
+
+
+def test_unrelated_image_path_is_not_stripped(attach_dir, tmp_path):
+    """A non-U1 image path the model happens to mention must survive; only U1
+    artifacts get stripped."""
+    bed = _png(tmp_path, "bed_snapshot.jpg")
+    wf._arm_pending_attach("u1_2026_0709_abccb7", [bed], "op")
+    reply = (
+        "Reference shot /home/brent/holiday_preview.png for color.\n"
+        "/opt/data/snapmaker_u1/requests/u2026_bad/plate_1_preview.png\n"
+        "Reply YES."
+    )
+    out = ai.transform(response_text=reply, session_id="s")
+    assert out is not None
+    assert "/home/brent/holiday_preview.png" in out, "unrelated path must survive"
+    assert "u2026_bad" not in out, "the U1 path is still stripped"
+    assert bed in out, "the real bed photo is attached"
+
+
+def test_corrupt_marker_never_raises(attach_dir):
+    target = ai._marker_path_for_session()
+    target.write_text("{ this is not json")
+    # Must degrade to leaving the reply unchanged, not raise.
+    out = ai.transform(response_text="Reply YES.", session_id="s")
+    assert out is None
+
+
+def test_arm_is_noop_with_no_images(attach_dir):
+    wf._arm_pending_attach("u1_2026_0709_abccb7", [], "op")
+    assert not list(attach_dir.iterdir()), "no marker when there's nothing to attach"

--- a/tests/test_attachment_injector.py
+++ b/tests/test_attachment_injector.py
@@ -166,6 +166,40 @@ def test_unrelated_image_path_is_not_stripped(attach_dir, tmp_path):
     assert bed in out, "the real bed photo is attached"
 
 
+def test_review_doc_injected_as_bare_path(attach_dir, tmp_path):
+    """The review .md must be injected as a BARE path so core send_document's it.
+    The model's live failure was a MEDIA: directive on a mangled path, which core
+    drops for .md. Assert the bare doc path is injected and the mangled MEDIA line
+    (keyword + path) is gone."""
+    bed = _png(tmp_path, "bed_snapshot.jpg")
+    review = tmp_path / "review.md"
+    review.write_text("# Print review\n- part 1\n")
+    wf._arm_pending_attach("u1_2026_0709_abccb7", [bed], "brent",
+                           documents=[str(review)])
+    reply = (
+        "Plate and bed below.\n"
+        "MEDIA: /opt/data/snapmaker_u1/requests/u2026_0709_abccb7_review.md\n"
+        "Reply YES."
+    )
+    out = ai.transform(response_text=reply, session_id="s")
+    assert out is not None
+    assert bed in out, "bed photo injected"
+    assert str(review) in out, "review doc injected as a bare path"
+    assert "u2026_0709_abccb7_review.md" not in out, "mangled doc path stripped"
+    assert "MEDIA:" not in out, "orphaned MEDIA directive keyword removed"
+
+
+def test_documents_only_marker_still_injects(attach_dir, tmp_path):
+    """A marker with no images but a document still delivers the document."""
+    review = tmp_path / "review.md"
+    review.write_text("# review\n")
+    wf._arm_pending_attach("u1_2026_0709_abccb7", [], "brent",
+                           documents=[str(review)])
+    out = ai.transform(response_text="Review attached. Reply YES.", session_id="s")
+    assert out is not None
+    assert str(review) in out
+
+
 def test_corrupt_marker_never_raises(attach_dir):
     target = ai._marker_path_for_session()
     target.write_text("{ this is not json")

--- a/tests/test_attachment_injector.py
+++ b/tests/test_attachment_injector.py
@@ -1,14 +1,19 @@
-"""Tests for the v2.4 structural image attachment.
+"""Tests for the v2.4 structural attachment injector.
 
 The workflow (scripts/u1_kit_workflow.py `_arm_pending_attach`) and the plugin
-hook (plugin/src/snapmaker_u1/hooks/attachment_injector.py) are written
-independently and only meet through a marker file keyed by HERMES_SESSION_KEY.
-The load-bearing test is the round trip: what the writer drops, the reader picks
-up and turns into attached image paths, with the model's echoed paths (correct
-OR mangled) removed so exactly the real images attach.
+hook (plugin/src/snapmaker_u1/hooks/attachment_injector.py) meet only through a
+one-shot marker keyed by HERMES_SESSION_KEY. The load-bearing test is the round
+trip: what the writer drops, the reader validates and turns into attachments,
+with the model's echoed paths (correct OR mangled) removed so exactly the real
+artifacts attach.
+
+The marker is same-uid-writable and therefore untrusted, so the hook validates
+every path (real, non-symlink, known artifact name, under the requests root)
+before delivery. Several tests forge markers directly to prove those rejections.
 """
 
 import json
+import os
 import sys
 import time
 from pathlib import Path
@@ -23,63 +28,72 @@ from snapmaker_u1.hooks import attachment_injector as ai  # noqa: E402
 import u1_kit_workflow as wf  # scripts/ is on the path via conftest  # noqa: E402
 
 _SESSION_KEY = "telegram:987654:main"
+_RID = "u1_2026_0709_abccb7"
 
 
 @pytest.fixture
 def attach_dir(tmp_path, monkeypatch):
-    """Point both the writer and the reader at the same throwaway marker dir and
-    pin a known session key."""
+    """Point writer and reader at the same throwaway marker dir + requests root,
+    and pin a known session key."""
     d = tmp_path / "pending_attach"
     d.mkdir()
+    req_root = tmp_path / "requests"
+    req_root.mkdir()
     monkeypatch.setattr(ai, "_PENDING_ATTACH_DIR", d)
     monkeypatch.setattr(wf, "_PENDING_ATTACH_DIR", d)
+    monkeypatch.setattr(ai, "_REQUESTS_ROOT", req_root)
     monkeypatch.setenv("HERMES_SESSION_KEY", _SESSION_KEY)
     return d
 
 
-def _png(tmp_path, name):
-    p = tmp_path / name
+def _artifact(tmp_path, name, rid=_RID):
+    """Create a valid U1 artifact at <requests_root>/<rid>/<name>."""
+    d = tmp_path / "requests" / rid
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / name
     p.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
     return str(p)
 
+
+def _write_marker(session_key, payload):
+    """Forge a marker directly (bypassing the workflow writer) at the hook's
+    session slot, to exercise validation/rejection paths."""
+    digest = __import__("hashlib").sha256(session_key.encode()).hexdigest()[:16]
+    p = ai._PENDING_ATTACH_DIR / f"{digest}.json"
+    p.write_text(json.dumps(payload))
+    return p
+
+
+# --------------------------------------------------------------------------- #
+# Happy path
+# --------------------------------------------------------------------------- #
 
 def test_no_marker_is_noop(attach_dir):
     assert ai.transform(response_text="Reply YES to start.", session_id="s") is None
 
 
 def test_roundtrip_strips_mangled_path_and_attaches_real_ones(attach_dir, tmp_path):
-    preview = _png(tmp_path, "plate_1_preview.png")
-    bed = _png(tmp_path, "bed_snapshot.jpg")
-    # Writer side (what the workflow does at the readiness card).
-    wf._arm_pending_attach("u1_2026_0709_abccb7", [preview, bed], "op")
+    preview = _artifact(tmp_path, "plate_1_preview.png")
+    bed = _artifact(tmp_path, "bed_snapshot.jpg")
+    wf._arm_pending_attach(_RID, [preview, bed], "op")
     assert list(attach_dir.iterdir()), "marker should exist after arming"
 
-    # Model mangled the request id, so its echoed path points at nothing.
     reply = (
         "Here is your plate and the current bed.\n"
         "/opt/data/snapmaker_u1/requests/u2026_bad/plate_1_preview.png\n"
         "Reply YES to start the print."
     )
     out = ai.transform(response_text=reply, session_id="s")
-
     assert out is not None
-    # Real paths injected...
     assert preview in out and bed in out
-    # ...the mangled one is gone (won't leak as text).
     assert "u2026_bad" not in out
-    # Prose is preserved.
     assert "Reply YES to start the print." in out
-    # Marker consumed (one-shot).
     assert not list(attach_dir.iterdir()), "marker must be consumed"
 
 
 def test_space_dollar_split_mangle_is_fully_stripped(attach_dir, tmp_path):
-    """The exact live 2026-07-09 reprint failure: gemma emitted
-    'requests/ $u1_..._8dfe85/bed_snapshot.jpg' which whitespace-splits into a
-    bare '/snapmaker_u1/requests/' prefix plus a '$..._8dfe85/bed_snapshot.jpg'
-    tail. Neither fragment may survive; the real bed photo is attached instead."""
-    bed = _png(tmp_path, "bed_snapshot.jpg")  # authoritative, in /tmp (no U1 dir sig)
-    wf._arm_pending_attach("u1_2026_0709_8dfe85", [bed], "brent")
+    bed = _artifact(tmp_path, "bed_snapshot.jpg")
+    wf._arm_pending_attach(_RID, [bed], "brent")
     reply = (
         "2\n"
         "/opt/data/snapmaker_u1/requests/ $u1_2026_0709_8dfe85/bed_snapshot.jpg\n"
@@ -91,13 +105,12 @@ def test_space_dollar_split_mangle_is_fully_stripped(attach_dir, tmp_path):
     assert bed in out, "real bed photo injected"
     assert "$u1_2026_0709_8dfe85" not in out, "mangled tail stripped"
     assert "snapmaker_u1/requests" not in out, "mangled dir prefix stripped too"
-    assert "Reply YES to start." in out, "prose kept"
+    assert "Reply YES to start." in out
 
 
 def test_correct_echo_is_not_doubled(attach_dir, tmp_path):
-    preview = _png(tmp_path, "plate_1_preview.png")
-    wf._arm_pending_attach("u1_2026_0709_abccb7", [preview], "op")
-    # Model happened to echo the correct path this time.
+    preview = _artifact(tmp_path, "plate_1_preview.png")
+    wf._arm_pending_attach(_RID, [preview], "op")
     reply = f"Plate ready.\n{preview}\nReply YES."
     out = ai.transform(response_text=reply, session_id="s")
     assert out is not None
@@ -105,55 +118,42 @@ def test_correct_echo_is_not_doubled(attach_dir, tmp_path):
 
 
 def test_inline_path_stripped_keeps_prose(attach_dir, tmp_path):
-    bed = _png(tmp_path, "bed_snapshot.jpg")
-    wf._arm_pending_attach("u1_2026_0709_abccb7", [bed], "op")
+    bed = _artifact(tmp_path, "bed_snapshot.jpg")
+    wf._arm_pending_attach(_RID, [bed], "op")
     reply = f"Current bed photo {bed} looks clear."
     out = ai.transform(response_text=reply, session_id="s")
     assert out is not None
     assert "looks clear." in out
-    # The inline path token is removed from the prose line, then re-appended bare.
     assert out.rstrip().endswith(bed)
 
 
-def test_nonexistent_images_and_no_echo_is_noop(attach_dir, tmp_path):
-    missing = str(tmp_path / "gone" / "plate_1_preview.png")  # never created
-    wf._arm_pending_attach("u1_2026_0709_abccb7", [missing], "op")
-    reply = "Reply YES to start."
+def test_review_doc_injected_as_bare_path(attach_dir, tmp_path):
+    bed = _artifact(tmp_path, "bed_snapshot.jpg")
+    review = _artifact(tmp_path, "review.md")
+    wf._arm_pending_attach(_RID, [bed], "brent", documents=[review])
+    reply = (
+        "Plate and bed below.\n"
+        "MEDIA: /opt/data/snapmaker_u1/requests/u2026_0709_abccb7_review.md\n"
+        "Reply YES."
+    )
     out = ai.transform(response_text=reply, session_id="s")
-    # Nothing exists to attach and nothing was echoed to strip -> leave reply be.
-    assert out is None
-    assert not list(attach_dir.iterdir()), "marker still consumed"
+    assert out is not None
+    assert bed in out and review in out
+    assert "u2026_0709_abccb7_review.md" not in out
+    assert "MEDIA:" not in out
 
 
-def test_stale_marker_discarded(attach_dir, tmp_path):
-    preview = _png(tmp_path, "plate_1_preview.png")
-    # Hand-write a marker that is older than the TTL at the hashed path.
-    target = ai._marker_path_for_session()
-    target.write_text(json.dumps({
-        "request_id": "u1_2026_0709_old",
-        "images": [preview],
-        "operator": "op",
-        "created_at": time.time() - (ai._PENDING_ATTACH_TTL_S + 60),
-    }))
-    out = ai.transform(response_text="Reply YES.", session_id="s")
-    assert out is None, "a stale marker must not attach"
-    assert not target.exists(), "stale marker is still consumed"
-
-
-def test_keyed_by_session_key(attach_dir, tmp_path, monkeypatch):
-    preview = _png(tmp_path, "plate_1_preview.png")
-    # Arm under a DIFFERENT session key than the one the hook will read.
-    wf._arm_pending_attach("u1_2026_0709_abccb7", [preview], "op",
-                           session_key="telegram:OTHER:main")
-    out = ai.transform(response_text="Reply YES.", session_id="s")
-    assert out is None, "a marker for another session must not be picked up"
+def test_documents_only_marker_still_injects(attach_dir, tmp_path):
+    review = _artifact(tmp_path, "review.md")
+    wf._arm_pending_attach(_RID, [], "brent", documents=[review])
+    out = ai.transform(response_text="Review attached. Reply YES.", session_id="s")
+    assert out is not None
+    assert review in out
 
 
 def test_unrelated_image_path_is_not_stripped(attach_dir, tmp_path):
-    """A non-U1 image path the model happens to mention must survive; only U1
-    artifacts get stripped."""
-    bed = _png(tmp_path, "bed_snapshot.jpg")
-    wf._arm_pending_attach("u1_2026_0709_abccb7", [bed], "op")
+    bed = _artifact(tmp_path, "bed_snapshot.jpg")
+    wf._arm_pending_attach(_RID, [bed], "op")
     reply = (
         "Reference shot /home/brent/holiday_preview.png for color.\n"
         "/opt/data/snapmaker_u1/requests/u2026_bad/plate_1_preview.png\n"
@@ -162,52 +162,121 @@ def test_unrelated_image_path_is_not_stripped(attach_dir, tmp_path):
     out = ai.transform(response_text=reply, session_id="s")
     assert out is not None
     assert "/home/brent/holiday_preview.png" in out, "unrelated path must survive"
-    assert "u2026_bad" not in out, "the U1 path is still stripped"
-    assert bed in out, "the real bed photo is attached"
+    assert "u2026_bad" not in out
+    assert bed in out
 
 
-def test_review_doc_injected_as_bare_path(attach_dir, tmp_path):
-    """The review .md must be injected as a BARE path so core send_document's it.
-    The model's live failure was a MEDIA: directive on a mangled path, which core
-    drops for .md. Assert the bare doc path is injected and the mangled MEDIA line
-    (keyword + path) is gone."""
-    bed = _png(tmp_path, "bed_snapshot.jpg")
-    review = tmp_path / "review.md"
-    review.write_text("# Print review\n- part 1\n")
-    wf._arm_pending_attach("u1_2026_0709_abccb7", [bed], "brent",
-                           documents=[str(review)])
-    reply = (
-        "Plate and bed below.\n"
-        "MEDIA: /opt/data/snapmaker_u1/requests/u2026_0709_abccb7_review.md\n"
-        "Reply YES."
-    )
-    out = ai.transform(response_text=reply, session_id="s")
-    assert out is not None
-    assert bed in out, "bed photo injected"
-    assert str(review) in out, "review doc injected as a bare path"
-    assert "u2026_0709_abccb7_review.md" not in out, "mangled doc path stripped"
-    assert "MEDIA:" not in out, "orphaned MEDIA directive keyword removed"
+# --------------------------------------------------------------------------- #
+# Security: the marker is untrusted (audit #2)
+# --------------------------------------------------------------------------- #
+
+def test_forged_path_outside_root_refused(attach_dir, tmp_path):
+    """A forged marker pointing at /etc/hosts must never be delivered."""
+    _write_marker(_SESSION_KEY, {
+        "request_id": _RID, "images": ["/etc/hosts"], "documents": [],
+        "operator": "op", "created_at": time.time(),
+    })
+    out = ai.transform(response_text="Reply YES.", session_id="s")
+    assert out is None, "no injectable artifact -> reply unchanged"
+    assert not list(attach_dir.iterdir()), "marker still consumed"
 
 
-def test_documents_only_marker_still_injects(attach_dir, tmp_path):
-    """A marker with no images but a document still delivers the document."""
-    review = tmp_path / "review.md"
-    review.write_text("# review\n")
-    wf._arm_pending_attach("u1_2026_0709_abccb7", [], "brent",
-                           documents=[str(review)])
-    out = ai.transform(response_text="Review attached. Reply YES.", session_id="s")
-    assert out is not None
-    assert str(review) in out
-
-
-def test_corrupt_marker_never_raises(attach_dir):
-    target = ai._marker_path_for_session()
-    target.write_text("{ this is not json")
-    # Must degrade to leaving the reply unchanged, not raise.
+def test_disallowed_name_under_root_refused(attach_dir, tmp_path):
+    """A real file in a valid request dir but with a non-artifact name is refused."""
+    secret = _artifact(tmp_path, "secret.png")  # valid location, wrong name
+    _write_marker(_SESSION_KEY, {
+        "request_id": _RID, "images": [secret], "documents": [],
+        "operator": "op", "created_at": time.time(),
+    })
     out = ai.transform(response_text="Reply YES.", session_id="s")
     assert out is None
 
 
+def test_symlinked_artifact_refused(attach_dir, tmp_path):
+    """A symlink named like an artifact but pointing outside is refused."""
+    link = tmp_path / "requests" / _RID / "bed_snapshot.jpg"
+    link.parent.mkdir(parents=True, exist_ok=True)
+    target = tmp_path / "outside.jpg"
+    target.write_bytes(b"x")
+    os.symlink(target, link)
+    _write_marker(_SESSION_KEY, {
+        "request_id": _RID, "images": [str(link)], "documents": [],
+        "operator": "op", "created_at": time.time(),
+    })
+    out = ai.transform(response_text="Reply YES.", session_id="s")
+    assert out is None
+
+
+def test_missing_file_refused(attach_dir, tmp_path):
+    missing = str(tmp_path / "requests" / _RID / "bed_snapshot.jpg")  # never created
+    _write_marker(_SESSION_KEY, {
+        "request_id": _RID, "images": [missing], "documents": [],
+        "operator": "op", "created_at": time.time(),
+    })
+    assert ai.transform(response_text="Reply YES.", session_id="s") is None
+
+
+# --------------------------------------------------------------------------- #
+# Timestamp validation (audit #6)
+# --------------------------------------------------------------------------- #
+
+def test_missing_timestamp_marker_rejected(attach_dir, tmp_path):
+    bed = _artifact(tmp_path, "bed_snapshot.jpg")
+    _write_marker(_SESSION_KEY, {"request_id": _RID, "images": [bed]})  # no created_at
+    assert ai.transform(response_text="Reply YES.", session_id="s") is None
+
+
+def test_string_timestamp_marker_rejected(attach_dir, tmp_path):
+    bed = _artifact(tmp_path, "bed_snapshot.jpg")
+    _write_marker(_SESSION_KEY, {
+        "request_id": _RID, "images": [bed], "created_at": "soon"})
+    assert ai.transform(response_text="Reply YES.", session_id="s") is None
+
+
+def test_stale_marker_discarded(attach_dir, tmp_path):
+    bed = _artifact(tmp_path, "bed_snapshot.jpg")
+    target = _write_marker(_SESSION_KEY, {
+        "request_id": _RID, "images": [bed],
+        "created_at": time.time() - (ai._PENDING_ATTACH_TTL_S + 60)})
+    assert ai.transform(response_text="Reply YES.", session_id="s") is None
+    assert not target.exists(), "stale marker is still consumed"
+
+
+# --------------------------------------------------------------------------- #
+# Session correlation + one-shot (audit #3, #4)
+# --------------------------------------------------------------------------- #
+
+def test_empty_session_key_writes_no_marker(attach_dir, tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+    bed = _artifact(tmp_path, "bed_snapshot.jpg")
+    wf._arm_pending_attach(_RID, [bed], "op")  # empty key -> no marker
+    assert not list(attach_dir.iterdir()), "empty-key slot must not be armed"
+    assert ai.transform(response_text="Reply YES.", session_id="s") is None
+
+
+def test_keyed_by_session_key(attach_dir, tmp_path):
+    preview = _artifact(tmp_path, "plate_1_preview.png")
+    wf._arm_pending_attach(_RID, [preview], "op",
+                           session_key="telegram:OTHER:main")
+    out = ai.transform(response_text="Reply YES.", session_id="s")
+    assert out is None, "a marker for another session must not be picked up"
+
+
+def test_marker_is_single_use(attach_dir, tmp_path):
+    bed = _artifact(tmp_path, "bed_snapshot.jpg")
+    wf._arm_pending_attach(_RID, [bed], "op")
+    first = ai.transform(response_text="Reply YES.", session_id="s")
+    second = ai.transform(response_text="Reply YES.", session_id="s")
+    assert first is not None and bed in first
+    assert second is None, "the marker must be consumed exactly once"
+
+
+def test_corrupt_marker_never_raises(attach_dir):
+    digest = __import__("hashlib").sha256(_SESSION_KEY.encode()).hexdigest()[:16]
+    (ai._PENDING_ATTACH_DIR / f"{digest}.json").write_text("{ this is not json")
+    assert ai.transform(response_text="Reply YES.", session_id="s") is None
+
+
 def test_arm_is_noop_with_no_images(attach_dir):
-    wf._arm_pending_attach("u1_2026_0709_abccb7", [], "op")
+    wf._arm_pending_attach(_RID, [], "op")
     assert not list(attach_dir.iterdir()), "no marker when there's nothing to attach"


### PR DESCRIPTION
Structural image + review-doc attach (kills the model-echo dependency), the reprint CANCEL button fix, marker hardening from the branch review, and the Hermes install now installs the snapmaker_u1 plugin. Verified live + full suite green (only the 2 slicer-env tests fail, they need a real slicer).