### PR TITLE
v2.4.2: chat-template sanitizer + mangled-upload-path recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2.4.2] — 2026-07-13
+
+Cleaner operator messages when the local model leaks chat-template tokens.
+
+### Fixed
+
+- **Leaked chat-template tokens are stripped from the reply.** The local models
+  this toolkit is documented to run (gemma4 over Ollama) are imported with a
+  bare passthrough template, so the model intermittently leaks its
+  reasoning-channel delimiters (`<channel|>`, `<|tool_call|>` ...) into the
+  visible message, most often as a `thought <channel|>` prefix. A new sanitizer
+  removes the known control tokens from the outbound reply on every turn, so the
+  operator sees clean text regardless of model or Ollama endpoint. It never
+  touches the safety gate, a structured tool call, or a file path, and a clean
+  reply passes through unchanged. Validated on real hardware and against the
+  live transcript store.
+
+---
+
 ## [2.4.1] — 2026-07-12
 
 Native Windows support, so the print operator runs on a Windows Hermes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [2.4.2] — 2026-07-13
 
-Cleaner operator messages when the local model leaks chat-template tokens.
+Reliability fixes for driving the printer with a small local model that
+occasionally garbles its own output.
 
 ### Fixed
 
@@ -22,6 +23,15 @@ Cleaner operator messages when the local model leaks chat-template tokens.
   touches the safety gate, a structured tool call, or a file path, and a clean
   reply passes through unchanged. Validated on real hardware and against the
   live transcript store.
+- **A mistyped upload name is recovered by its stable id.** The model sometimes
+  retypes an uploaded file's name and mangles the human-readable suffix (a `+`
+  becomes `_`), so the path it passes points at nothing. The workflow then
+  mis-read the missing archive as a single model, handed the zip to the
+  single-model parser, and failed with a confusing "unsupported model file". The
+  upload's stable `doc_<hash>` prefix now recovers the real file, so the kit
+  ingests as normal. A zip that is genuinely missing or unreadable surfaces a
+  clear message instead of silently falling into the single-model path; a zip
+  holding a single object is still handled as a kit-of-one.
 
 ---
 

--- a/plugin/src/snapmaker_u1/hooks/attachment_injector.py
+++ b/plugin/src/snapmaker_u1/hooks/attachment_injector.py
@@ -75,6 +75,7 @@ logger = logging.getLogger(__name__)
 #   content : {"request_id": str, "images": [abs path, ...],
 #              "operator": str|None, "created_at": float}
 from ..pending import pending_dir as _resolve_pending_dir
+from .channel_sanitizer import sanitize_channel_leak
 
 _PENDING_ATTACH_DIR = _resolve_pending_dir("attach")
 # Images are only relevant to the immediate reply; a marker older than this is
@@ -357,9 +358,24 @@ def transform(response_text: str = "", session_id: str = "", model: str = "",
     Returns a replacement string, or None to leave the reply unchanged.
     """
     try:
+        # Always clean leaked chat-template control tokens from the visible reply.
+        # Every gemma4 Ollama import ships a passthrough template and leaks
+        # <channel|> etc. into content (measured ~25-75% of turns, any turn type),
+        # so this runs independent of any U1 image card.
+        sanitized = sanitize_channel_leak(response_text or "")
+        leak_stripped = sanitized != (response_text or "")
+
         marker = _load_and_consume_marker()
         if not marker:
-            return None  # no U1 card this turn -> no-op
+            # No U1 card this turn. Still replace the reply when we removed a leaked
+            # token and readable text remains, so the operator never sees <channel|>
+            # cruft. A wholly-leaked turn sanitizes to "" (falsy -> turn_finalizer
+            # leaves it unchanged): nothing to show, and blanking is not our call.
+            if leak_stripped and sanitized:
+                logger.info("snapmaker_u1 attachment_injector: stripped leaked "
+                            "chat-template token(s) from reply")
+                return sanitized
+            return None  # clean reply, no card -> no-op
 
         # Authoritative attachments = images + documents, in that order. Every
         # path is validated (real, non-symlink, known artifact name, under the
@@ -378,7 +394,7 @@ def transform(response_text: str = "", session_id: str = "", model: str = "",
                                "that is not a known U1 artifact under the "
                                "requests root: %r", sp)
 
-        cleaned = _strip_echoed_u1_images(response_text or "")
+        cleaned = _strip_echoed_u1_images(sanitized)
 
         if not paths:
             # Marker existed but nothing survives on disk. Return the cleaned

--- a/plugin/src/snapmaker_u1/hooks/channel_sanitizer.py
+++ b/plugin/src/snapmaker_u1/hooks/channel_sanitizer.py
@@ -1,0 +1,75 @@
+"""Strip leaked chat-template control tokens from the model's visible reply.
+
+Why this exists
+---------------
+The local models this toolkit is documented to run (gemma4 over Ollama) are
+imported with a bare ``{{ .Prompt }}`` Ollama template - every gemma4 variant
+ships the same passthrough template. A reasoning-formatted model with no
+template to structure or parse its channels leaks the raw delimiters
+(``<|channel|>``, ``<channel|>``, ``<|tool_call|>`` ...) straight into the
+assistant's content, most often as a ``thought <channel|>`` prefix on the
+operator's message. Measured on the real transcript store: the leak lands on
+roughly 75% of tool-call turns over Ollama's ``/v1`` compatibility endpoint and
+25-40% over native ``/api/chat`` - neither is clean, and it happens on any turn
+(errors, form-open, plain replies), not only on the image card.
+
+It is a serving/import defect, not a toolkit bug and not a fundamental limit of
+the model: a correctly-templated import would not leak. But the toolkit should
+not trust model output either way, so this removes the known control tokens from
+the VISIBLE text before the operator ever sees them. It is deliberately
+model-agnostic (any client's reply passes through) and endpoint-agnostic.
+
+Scope / non-goals
+-----------------
+This cleans the operator's readable message only. It never touches the safety
+gate (which validates real gcode, never model text), a structured tool call, or
+a file path. A turn whose ENTIRE content is a leak (no real text) is left to the
+caller - there is nothing to show, and blanking a reply is not this function's
+call. The ``call:terminal{...}`` shape (a tool call the serializer failed to
+parse into a real call) is a functional failure, not cosmetic, so it is
+intentionally NOT stripped here - hiding it would hide a dropped action.
+"""
+from __future__ import annotations
+
+import re
+
+# Known harmony / channel control-token names. Matched both correctly-delimited
+# (``<|channel|>``) and in the leaked half-delimited form (``<channel|>``) the
+# serializer emits. Restricted to a fixed allowlist of token names so an ordinary
+# ``<|something|>`` in prose is never touched - conservative on purpose.
+_LEAK_TOKEN_RE = re.compile(
+    r"<\|?(?:channel|tool_call|message|start|end|final|analysis|commentary|"
+    r"constrain|assistant|user|system|return|think|thinking)\|>"
+)
+# The ``<|"|>`` fragment seen jammed into leaked ``call:terminal{command:<|"|>...``
+_QUOTE_GARBAGE_RE = re.compile(r'<\|"\|>')
+# A leading reasoning label ("thought") that directly precedes a channel token
+# is part of the leak, not prose. Only stripped when a channel/analysis/think
+# token follows it, so a real sentence starting with "Thought ..." is untouched.
+_LEADING_THOUGHT_RE = re.compile(
+    r"^\s*thought\s+(?=<\|?(?:channel|message|analysis|think|thinking)\|>)",
+    re.IGNORECASE,
+)
+
+
+def sanitize_channel_leak(text: str) -> str:
+    """Return ``text`` with leaked chat-template control tokens removed.
+
+    Fast-paths clean text: if the reply carries no ``|>`` control-token marker it
+    is returned unchanged (the overwhelmingly common case, so a normal message is
+    never rewritten). Otherwise the leading reasoning label, every known control
+    token, and the ``<|"|>`` fragment are removed, and the whitespace the removals
+    leave behind is tidied. Returns an empty string when the content was nothing
+    but a leak - the caller decides what an empty result means.
+    """
+    if not text or "|>" not in text:
+        return text
+    cleaned = _LEADING_THOUGHT_RE.sub("", text, count=1)
+    cleaned = _LEAK_TOKEN_RE.sub("", cleaned)
+    cleaned = _QUOTE_GARBAGE_RE.sub("", cleaned)
+    # Tidy the gaps the removals leave: runs of spaces, trailing spaces on a
+    # line, and 3+ blank lines collapsed to a single paragraph break.
+    cleaned = re.sub(r"[ \t]{2,}", " ", cleaned)
+    cleaned = re.sub(r"[ \t]+\n", "\n", cleaned)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.strip()

--- a/scripts/u1_kit.py
+++ b/scripts/u1_kit.py
@@ -157,6 +157,28 @@ def is_multi_part_archive(archive: Path) -> bool:
     return count_archive_stls(archive) > 1
 
 
+def resolve_upload_path(path: Path) -> Path:
+    """Map a possibly-mangled upload path back to the real file on disk.
+
+    The driving agent sometimes retypes an uploaded doc's name and mangles the
+    human-readable suffix (e.g. a '+' becomes '_'), but the ``doc_<hash>``
+    prefix is unique and stable. If ``path`` is missing, glob the parent for
+    that prefix and use the sole match; fall back to ``path`` when the basename
+    isn't a doc upload, the glob is ambiguous, or any FS access fails.
+    """
+    path = Path(path)
+    if path.exists():
+        return path
+    m = re.match(r"^(doc_[0-9a-f]{6,})_", path.name)
+    if not m:
+        return path
+    try:
+        matches = [p for p in path.parent.glob(f"{m.group(1)}_*") if p.is_file()]
+    except Exception:
+        return path
+    return matches[0] if len(matches) == 1 else path
+
+
 def part_fits_bed(
     footprint_mm: tuple[float, float] | list[float],
     bed_mm: tuple[float, float] = DEFAULT_BED_MM,

--- a/scripts/u1_kit_workflow.py
+++ b/scripts/u1_kit_workflow.py
@@ -2310,6 +2310,9 @@ def run_kit_workflow(args) -> dict[str, Any]:
             "model_path in request.json. Re-invoke with the kit zip path."
         )
     archive = Path(model_arg).resolve()
+    # Belt-and-suspenders for agent path-mangling: if the retyped name lost its
+    # human suffix, recover the real upload by its stable doc-hash prefix.
+    archive = u1_kit.resolve_upload_path(archive)
     if self_healed:
         # make the self-heal visible in audit
         # so the underlying agent-paraphrasing pattern is detectable later.

--- a/scripts/u1_slice_workflow.py
+++ b/scripts/u1_slice_workflow.py
@@ -1659,24 +1659,34 @@ def run_workflow(args)->dict[str,Any]:
     # is the gate-detection principle: the SCRIPT detects the kit; the agent
     # just runs the emitted command (one entrypoint to call, no zip-inspection
     # judgment asked of a small model).
+    _kit_err = None
     try:
         import u1_kit
+        # The agent sometimes retypes the upload path and mangles the human
+        # suffix (a '+' becomes '_'); the doc-hash prefix is stable, so recover
+        # the real file BEFORE detection (a mangled path exists as no file at
+        # all, so detection would see an empty/absent archive).
+        model = u1_kit.resolve_upload_path(model)
         _is_kit = u1_kit.is_multi_part_archive(model)
     except Exception as _kit_exc:
         _is_kit = False
-        # A zip we couldn't inspect must NOT silently fall into the
-        # single-STL flow — that flow extracts the FIRST model only and
-        # would print a fraction of the kit with no warning.
-        if str(model).lower().endswith('.zip'):
-            emit({'stage': 'kit_detection_failed',
-                  'error': f'{type(_kit_exc).__name__}: {_kit_exc}',
-                  'instruction': ('Could not inspect this zip for multiple '
-                                  'STLs. Do NOT continue with the single-STL '
-                                  'flow — it would slice only the first '
-                                  'model. Surface this error to the '
-                                  'operator.')},
-                 args.json_events)
-            return {'phase': 'kit_detection_failed', 'model': str(model)}
+        _kit_err = f'{type(_kit_exc).__name__}: {_kit_exc}'
+    # A zip that is MISSING or UNREADABLE must NOT fall into the single-STL flow
+    # (which would hand the zip itself to the single-model parser and fail with a
+    # confusing "unsupported model file"). The agent occasionally mangles the
+    # upload name so the path no longer exists; resolve_upload_path above recovers
+    # most of those, but if it still cannot be found or inspected, say so plainly.
+    # A zip that EXISTS with a single object is a valid kit-of-one and routes on.
+    if str(model).lower().endswith('.zip') and (_kit_err is not None
+                                                or not Path(model).exists()):
+        emit({'stage': 'kit_detection_failed',
+              'error': _kit_err or f'archive not found: {model}',
+              'instruction': ('Could not read this zip archive. The upload name '
+                              'may have been mistyped; check the file exists, '
+                              'then surface this to the operator. Do NOT fall '
+                              'back to the single-STL flow.')},
+             args.json_events)
+        return {'phase': 'kit_detection_failed', 'model': str(model)}
     # v2.2 UNIFIED FLOW: every model routes to the kit workflow. A single STL is
     # a kit-of-1 — the kit workflow ingests a lone STL as one part, and Phase 1
     # gave it the single-model orientation verdict — so it handles single AND

--- a/tests/test_channel_sanitizer.py
+++ b/tests/test_channel_sanitizer.py
@@ -1,0 +1,96 @@
+"""Tests for the leaked chat-template token sanitizer.
+
+Strings marked "real" are taken verbatim from the live transcript store
+(state.db) where gemma4 over Ollama leaked the token into the operator's reply.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+_PLUGIN_SRC = Path(__file__).resolve().parent.parent / "plugin" / "src"
+sys.path.insert(0, str(_PLUGIN_SRC))
+
+from snapmaker_u1.hooks.channel_sanitizer import sanitize_channel_leak  # noqa: E402
+from snapmaker_u1.hooks import attachment_injector as ai  # noqa: E402
+
+
+# --- the sanitizer in isolation -------------------------------------------
+
+def test_bare_leak_only_becomes_empty():
+    # real: assistant content stored as exactly "thought <channel|>" (len 18)
+    assert sanitize_channel_leak("thought <channel|>") == ""
+
+
+def test_leak_prefix_before_real_text_keeps_the_text():
+    # real shape: "thought <channel|>On it - running the Snapmaker U1 workflow..."
+    assert sanitize_channel_leak(
+        "thought <channel|>On it, running the workflow.") == "On it, running the workflow."
+
+
+def test_bare_channel_prefix_stripped():
+    # real: "<channel|>The toolkit was unable to process this model..."
+    assert sanitize_channel_leak(
+        "<channel|>The toolkit was unable to process this model.") == \
+        "The toolkit was unable to process this model."
+
+
+def test_leak_prefix_before_a_path_keeps_the_path():
+    # real: "<channel|>/opt/data/snapmaker_u1/requests/u1_2026_0709_4bcf1f/plate_1_preview.png"
+    p = "/opt/data/snapmaker_u1/requests/u1_2026_0709_4bcf1f/plate_1_preview.png"
+    assert sanitize_channel_leak("thought <channel|>" + p) == p
+
+
+def test_full_pipe_delimited_tokens_removed():
+    assert sanitize_channel_leak("Do it <|tool_call|> now.") == "Do it now."
+
+
+def test_quote_garbage_fragment_removed():
+    assert sanitize_channel_leak('call it <|"|> here') == "call it here"
+
+
+def test_clean_text_is_returned_unchanged():
+    msg = "The bed is clear. Reply YES to start now, or NO to keep the gcode."
+    assert sanitize_channel_leak(msg) == msg
+
+
+def test_leading_word_thought_in_prose_is_untouched():
+    # "Thought" as a real word (no channel token after it) must survive.
+    msg = "Thought about the orientation, laying it flat is best."
+    assert sanitize_channel_leak(msg) == msg
+
+
+def test_unknown_pipe_token_is_not_stripped():
+    # Conservative: only the known control-token names are removed.
+    msg = "Use the <|widget|> carefully."
+    assert sanitize_channel_leak(msg) == msg
+
+
+def test_empty_and_none_safe():
+    assert sanitize_channel_leak("") == ""
+    assert sanitize_channel_leak(None) is None
+
+
+def test_idempotent():
+    once = sanitize_channel_leak("thought <channel|>All set.")
+    assert sanitize_channel_leak(once) == once == "All set."
+
+
+# --- wired into the outbound hook -----------------------------------------
+
+def test_transform_strips_leak_when_no_card(monkeypatch):
+    # No marker this turn: the hook must still clean the leaked token.
+    monkeypatch.setattr(ai, "_load_and_consume_marker", lambda: None)
+    out = ai.transform(response_text="thought <channel|>Bed is clear, ready to print.")
+    assert out == "Bed is clear, ready to print."
+
+
+def test_transform_clean_reply_no_card_is_noop(monkeypatch):
+    monkeypatch.setattr(ai, "_load_and_consume_marker", lambda: None)
+    assert ai.transform(response_text="Bed is clear, ready to print.") is None
+
+
+def test_transform_wholly_leaked_reply_left_unchanged(monkeypatch):
+    # Sanitizes to "" -> returning "" would blank the message; hook returns None.
+    monkeypatch.setattr(ai, "_load_and_consume_marker", lambda: None)
+    assert ai.transform(response_text="thought <channel|>") is None

--- a/tests/test_u1_slice_workflow.py
+++ b/tests/test_u1_slice_workflow.py
@@ -1398,6 +1398,10 @@ def test_undetectable_zip_does_not_fall_into_single_flow(tmp_path, capsys, monke
 
     class _Boom:
         @staticmethod
+        def resolve_upload_path(p):
+            return p
+
+        @staticmethod
         def is_multi_part_archive(_):
             raise RuntimeError("corrupt central directory")
 

--- a/tests/test_upload_path_resolution.py
+++ b/tests/test_upload_path_resolution.py
@@ -1,0 +1,81 @@
+"""Tests for doc-hash upload-path recovery and the .zip single-flow guard.
+
+The driving agent occasionally mangles the human-readable suffix of an uploaded
+file name (a '+' turns into '_') so the typed path points at nothing. The
+``doc_<hash>`` prefix stays stable, so ``resolve_upload_path`` recovers the real
+file, and a .zip that can't be confirmed as a kit must never be handed to the
+single-STL flow (which would slice only the first model or fail outright).
+"""
+from __future__ import annotations
+
+import json
+import zipfile
+
+import u1_kit
+from u1_slice_workflow import main
+
+
+def _touch(p):
+    p.write_bytes(b"stub")
+    return p
+
+
+def test_resolve_finds_real_file_by_doc_hash_when_suffix_mangled(tmp_path):
+    real = _touch(tmp_path / "doc_abc123def456_real name.zip")
+    asked = tmp_path / "doc_abc123def456_MANGLED_name.zip"
+    assert u1_kit.resolve_upload_path(asked) == real
+
+
+def test_resolve_returns_path_unchanged_when_it_exists(tmp_path):
+    real = _touch(tmp_path / "doc_abc123def456_present.zip")
+    assert u1_kit.resolve_upload_path(real) == real
+
+
+def test_resolve_returns_path_unchanged_for_non_doc_basename(tmp_path):
+    _touch(tmp_path / "doc_abc123def456_real.zip")
+    asked = tmp_path / "just_a_model.zip"  # no doc_<hash> prefix
+    assert u1_kit.resolve_upload_path(asked) == asked
+
+
+def test_resolve_returns_path_unchanged_when_ambiguous(tmp_path):
+    _touch(tmp_path / "doc_abc123def456_one.zip")
+    _touch(tmp_path / "doc_abc123def456_two.zip")
+    asked = tmp_path / "doc_abc123def456_MANGLED.zip"
+    assert u1_kit.resolve_upload_path(asked) == asked
+
+
+def _real_zip(tmp_path):
+    zp = tmp_path / "kit.zip"
+    with zipfile.ZipFile(zp, "w") as z:
+        z.writestr("a.stl", b"solid a\nendsolid a\n")
+    return zp
+
+
+def test_existing_single_object_zip_routes_on_as_kit_of_one(
+        tmp_path, capsys, monkeypatch):
+    # A real, present .zip that is_multi_part_archive reports as not-multi is a
+    # valid kit-of-one (e.g. a single .3mf, or one STL): it must route on to the
+    # kit workflow, never be rejected. Guards against over-refusing.
+    zp = _real_zip(tmp_path)
+    monkeypatch.setattr(u1_kit, "is_multi_part_archive", lambda _p: False)
+    main([str(zp), "--json-events"])
+    events = [json.loads(l) for l in capsys.readouterr().out.splitlines()
+              if l.strip().startswith("{")]
+    stages = [e.get("stage") for e in events]
+    assert "kit_detected" in stages, stages
+    assert "kit_detection_failed" not in stages, stages
+
+
+def test_missing_zip_is_refused_not_parsed_as_single_model(
+        tmp_path, capsys, monkeypatch):
+    # A .zip path that does not exist (the agent mangled the name past recovery)
+    # must be surfaced clearly, never handed to the single-STL parser (which
+    # would fail with a confusing "unsupported model file").
+    missing = tmp_path / "doc_abc123def456_gone.zip"  # no such file on disk
+    monkeypatch.setattr(u1_kit, "is_multi_part_archive", lambda _p: False)
+    main([str(missing), "--json-events"])
+    events = [json.loads(l) for l in capsys.readouterr().out.splitlines()
+              if l.strip().startswith("{")]
+    stages = [e.get("stage") for e in events]
+    assert "kit_detection_failed" in stages, stages
+    assert "kit_detected" not in stages, stages


### PR DESCRIPTION
Two reliability fixes for driving the printer with a small local model that garbles its own output.

1. **Chat-template sanitizer.** The local gemma4-over-Ollama models leak reasoning-channel tokens (`<channel|>`, `<|tool_call|>` ...) into the visible reply. A new sanitizer strips the known control tokens from the outbound message on every turn, model- and endpoint-agnostic, never touching the safety gate, a structured tool call, or a file path.

2. **Mangled-upload-path recovery.** The model sometimes retypes an uploaded file's name and mangles the human-readable suffix (a `+` becomes `_`), so the path points at nothing and the kit failed with a confusing "unsupported model file". The upload's stable `doc_<hash>` prefix now recovers the real file; a genuinely missing or unreadable zip surfaces a clear message instead of falling into the single-model path, and a single-object zip is still handled as a kit-of-one.

Both validated on real hardware (channel leak stripped in a live drill; the 2-part kit that dead-stalled now ingests and slices). 942-pass broad suite plus targeted unit tests for each. CHANGELOG updated.