### PR TITLE
v2.4.3: model-free kit options form + robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2.4.3] — 2026-07-13
+
+The kit options form is now driven by the toolkit itself, from end to end. It is
+one more place where getting a print started no longer depends on a small local
+model relaying a fussy detail exactly right.
+
+### Changed
+
+- **The toolkit renders and collects the kit options form directly.** When you
+  send a kit, the toolkit now shows the options form (parts, tool, orientation,
+  supports, and the advanced settings), collects your answers, slices, and
+  returns the readiness card as one deterministic step. Before this, the model
+  had to ask for the form itself, and a small local model would sometimes garble
+  that request and stall the job. The model no longer types the form step at all,
+  so it cannot garble it. The plate previews, the fresh bed photo, the review
+  document, and the final bed-clear approval prompt all reach you unchanged, and
+  the safety gate is untouched.
+
+### Fixed
+
+- **A mistyped kit upload name is recovered before the job gives up.** The model
+  occasionally retypes an uploaded file's name and mangles the suffix (a `+`
+  becomes `_`), so the path points at nothing. The kit step now recovers the real
+  file by its stable upload id before failing, the same recovery the rest of the
+  workflow already had, so the kit ingests as normal. A genuinely missing or
+  ambiguous name is left alone rather than guessed.
+- **The first taps on a freshly shown form register.** On a brand-new options
+  form, a very fast first tap could land the instant the buttons appeared, before
+  the form finished registering, and would flash without checking the box. Early
+  taps are now held for a moment and applied once the form is ready.
+
+---
+
 ## [2.4.2] — 2026-07-13
 
 Reliability fixes for driving the printer with a small local model that

--- a/adapters/hermes/install.py
+++ b/adapters/hermes/install.py
@@ -413,7 +413,8 @@ def main(argv=None) -> int:
     # u1_form_telegram.py (the L1 pure renderer) is single-sourced from the
     # sibling adapters/telegram/ directory — the hermes tree carries no copy.
     renderer_src = here.parent / "telegram" / "u1_form_telegram.py"
-    tools_src = {"form_gateway.py": here / "tools" / "form_gateway.py"}
+    tools_src = {"form_gateway.py": here / "tools" / "form_gateway.py",
+                 "u1_kit_tool.py": here / "tools" / "u1_kit_tool.py"}
 
     print(f"venv:           {venv}")
     print(f"site-packages:  {sp}")
@@ -423,7 +424,7 @@ def main(argv=None) -> int:
     print()
 
     if a.uninstall:
-        for name in ("form_gateway.py",) + LEGACY_TOOLS_FILES:
+        for name in ("form_gateway.py", "u1_kit_tool.py") + LEGACY_TOOLS_FILES:
             tgt = tools_dir / name
             if tgt.exists():
                 if a.dry_run:

--- a/adapters/hermes/plugin/__init__.py
+++ b/adapters/hermes/plugin/__init__.py
@@ -143,7 +143,7 @@ def _form_handler(args: Dict[str, Any], **kwargs: Any) -> str:
 
 
 # =============================================================================
-# OpenAI Function-Calling Schema
+# Function-calling tool schema
 # =============================================================================
 
 FORM_SCHEMA = {

--- a/adapters/hermes/plugin/__init__.py
+++ b/adapters/hermes/plugin/__init__.py
@@ -243,3 +243,34 @@ def register(ctx) -> None:
         emoji="📝",
     )
     ctx.register_hook("pre_gateway_dispatch", _pre_gateway_dispatch)
+
+    # u1_kit: the deterministic kit entry point. The model calls this ONCE for a
+    # kit zip; the handler runs the workflow, renders the form ITSELF via
+    # form_gateway.invoke_form, collects the answer, re-invokes, and returns the
+    # readiness card -- the model never emits a mid-flow `form` tool call, so it
+    # cannot garble it. Registered on its own toolset (like `form`) so it is
+    # actually offered to the model (a bare tools/ drop registers but is never
+    # offered -- see this module's header). Lazy-imported so a non-gateway
+    # context (e.g. install.py's plugin verification) can still load the plugin.
+    try:
+        from tools.u1_kit_tool import u1_kit_tool as _kit_run, U1_KIT_SCHEMA
+
+        def _u1_kit_handler(args: Dict[str, Any], **_kw: Any) -> str:
+            return _kit_run(model_path=args.get("model_path", ""),
+                            request_id=args.get("request_id") or None)
+
+        ctx.register_tool(
+            name="u1_kit",
+            toolset="u1_kit",
+            schema=U1_KIT_SCHEMA,
+            handler=_u1_kit_handler,
+            description="Slice a multi-part 3D print kit (zip of STLs); renders "
+                        "its own operator form deterministically",
+            emoji="🖨️",
+        )
+        logger.info("snapmaker_u1 u1-form plugin: u1_kit tool registered "
+                    "(deterministic model-free form)")
+    except Exception:
+        logger.warning("snapmaker_u1 u1-form plugin: u1_kit tool NOT registered "
+                       "(kits fall back to the model-driven form path)",
+                       exc_info=True)

--- a/adapters/hermes/plugin/telegram_patch.py
+++ b/adapters/hermes/plugin/telegram_patch.py
@@ -317,9 +317,27 @@ def ensure_patched(adapter_cls) -> bool:
         # per-chat counters, so message_id alone can collide across two
         # concurrent forms in different chats.
         st = _form_state(self)
-        slot = next((s for s in st.values()
-                     if s["chat_id"] == msg.chat_id and s["msg_id"] == msg.message_id),
-                    None)
+
+        def _find_slot():
+            return next((s for s in st.values()
+                         if s["chat_id"] == msg.chat_id
+                         and s["msg_id"] == msg.message_id), None)
+
+        slot = _find_slot()
+        if slot is None:
+            # First-render race: Telegram makes the message tappable the instant
+            # it is delivered, but _send_form records the form slot just AFTER the
+            # send call returns. A fast tap in that window would otherwise flash
+            # "Stale form" with no check (live 2026-07-13: the operator's first
+            # taps on a fresh form didn't register). Briefly retry so the tap
+            # lands once the slot registers a fraction of a second later; a
+            # genuinely stale form never appears and still falls through.
+            import asyncio as _asyncio
+            for _ in range(10):
+                await _asyncio.sleep(0.1)
+                slot = _find_slot()
+                if slot is not None:
+                    break
         if slot is None:
             await q.answer("Stale form")
             return

--- a/adapters/hermes/tools/form_gateway.py
+++ b/adapters/hermes/tools/form_gateway.py
@@ -257,3 +257,53 @@ def get_form_callback(session_id: str = "") -> Optional[Any]:
         if key and key in _form_callbacks:
             return _form_callbacks[key]
         return _form_callbacks.get("__default__")
+
+
+# =========================================================================
+# Deterministic-tool API (used by the u1_kit tool)
+# =========================================================================
+#
+# A tool that drives the form itself (instead of the model picking the
+# `form` tool and relaying the kit_form event) needs just two things: to
+# confirm the gateway's per-turn form callback is wired for this session,
+# and to invoke it (render + block + return the answer). These wrap the
+# callback registry above so the tool never has to know the register/send/
+# wait plumbing -- that lives in the gateway's published callback
+# (_form_callback_sync, from the install.py run.py patch).
+
+def get_notify(session_id: str = "") -> Optional[Any]:
+    """The active form callback for a session, or None if none is wired.
+
+    An intent-revealing alias of ``get_form_callback`` for callers that just
+    want to check "is the form path installed for this session?" before using
+    it."""
+    return get_form_callback(session_id)
+
+
+def set_notify(session_id: str, callback: Any) -> None:
+    """Publish the form callback for a session. Alias of set_form_callback."""
+    set_form_callback(session_id, callback)
+
+
+def invoke_form(session_id: str, form_schema: Dict[str, Any]) -> Dict[str, Any]:
+    """Render ``form_schema`` to the operator and block until they submit,
+    returning the answer dict.
+
+    This is the deterministic entry point the u1_kit tool uses so the model
+    never has to emit a ``form`` tool call. It resolves the session's
+    published callback (the run.py patch's ``_form_callback_sync``) and calls
+    it; that callback registers the form, sends it through the platform
+    adapter, and waits on ``wait_for_response``. Returns ``{"_error": ...}``
+    when no callback is wired for the session, and never raises."""
+    cb = get_form_callback(session_id)
+    if cb is None:
+        return {"_error": "no form callback registered for this session "
+                          "(run adapters/hermes/install.py and restart Hermes)"}
+    try:
+        answer = cb(form_schema)
+    except Exception as exc:  # a form failure must not crash the driving tool
+        return {"_error": f"form callback raised: {exc}"}
+    if not isinstance(answer, dict):
+        return {"_error": f"form callback returned {type(answer).__name__}, "
+                          "expected an answer dict"}
+    return answer

--- a/adapters/hermes/tools/u1_kit_tool.py
+++ b/adapters/hermes/tools/u1_kit_tool.py
@@ -253,12 +253,25 @@ def u1_kit_tool(
             "events_tail": res2["events"][-5:],
         }, ensure_ascii=False)
 
-    return json.dumps({
+    # Re-surface the workflow's own render / review_doc / readiness event lines
+    # in this tool's output. The transform_tool_result attach hook
+    # (attachment_injector.arm_from_tool_result) arms the image marker by
+    # parsing render (image) + review_doc (path) JSON lines from the tool
+    # OUTPUT, gated on a bed_clear_start/kit_readiness_card marker being
+    # present. The terminal path exposes these lines directly (raw workflow
+    # stdout); this tool captured them into res2["events"], so it must re-emit
+    # them here or the plate previews + bed photo + review doc never attach.
+    _passthrough = "\n".join(
+        json.dumps(ev, ensure_ascii=False) for ev in res2["events"]
+        if ev.get("stage") in ("render", "review_doc", "kit_readiness_card",
+                               "bed_clear_start"))
+    _summary = json.dumps({
         "phase": "ready",
         "request_id": wf_request_id,
         "readiness_card": readiness,
         "user_answer": answer,
     }, ensure_ascii=False)
+    return f"{_passthrough}\n{_summary}" if _passthrough else _summary
 
 
 def check_u1_kit_requirements() -> bool:

--- a/adapters/hermes/tools/u1_kit_tool.py
+++ b/adapters/hermes/tools/u1_kit_tool.py
@@ -160,6 +160,30 @@ def _find_event(events: List[Dict[str, Any]], stage: str,
     return None
 
 
+def _resolve_upload_path(path: Path) -> Path:
+    """Recover a model-mangled upload path by its stable ``doc_<hash>`` prefix.
+
+    The model sometimes retypes an uploaded doc's name and mangles the human-
+    readable suffix (a '+' becomes '_', etc.), but the ``doc_<hash>`` prefix the
+    Telegram adapter assigns is unique and stable. If the path is missing, glob
+    the parent for that prefix and use the sole match. Mirrors
+    scripts/u1_kit.py:resolve_upload_path (#45); duplicated here rather than
+    imported because that module pulls in numpy and does host lookups at import
+    time, which must not load into the gateway process. Without this, u1_kit's
+    existence check rejects a mangled path before the workflow (which has the
+    same recovery) ever runs."""
+    if path.exists():
+        return path
+    m = re.match(r"^(doc_[0-9a-f]{6,})_", path.name)
+    if not m:
+        return path
+    try:
+        matches = [p for p in path.parent.glob(f"{m.group(1)}_*") if p.is_file()]
+    except Exception:
+        return path
+    return matches[0] if len(matches) == 1 else path
+
+
 def _is_passthrough_event(ev: Dict[str, Any]) -> bool:
     """Events u1_kit re-emits in its output so the gateway attach hook and the
     model see them: the renders (plate previews + bed photo), the review doc,
@@ -222,6 +246,9 @@ def u1_kit_tool(
         path = path.resolve()
     except OSError as exc:
         return json.dumps({"error": f"bad model_path: {exc}"}, ensure_ascii=False)
+    # Recover a model-mangled upload name (e.g. '+' retyped as '_') by its
+    # stable doc_<hash> prefix before the existence check bails.
+    path = _resolve_upload_path(path)
     if not path.exists():
         return json.dumps({"error": f"model not found: {path}"}, ensure_ascii=False)
 

--- a/adapters/hermes/tools/u1_kit_tool.py
+++ b/adapters/hermes/tools/u1_kit_tool.py
@@ -41,6 +41,7 @@ import re
 import shlex
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -106,11 +107,24 @@ def _run_workflow(args: List[str], *, timeout: float) -> Dict[str, Any]:
     The workflow exits naturally at phase boundaries (after kit_form in the
     analyze phase, after kit_readiness_card in the slice phase), so a simple
     communicate() is enough — no need to stream while it runs.
+
+    Runs in a throwaway working directory. Orca writes a log (``00000.log``) to
+    the process CWD, and this tool spawns from inside the gateway process whose
+    CWD (/opt/hermes) is not writable, so a bare spawn crashed the slice with a
+    filesystem I/O error (the terminal-driven fallback never hit this because
+    the terminal tool runs from a writable dir). The workflow resolves every
+    real path absolutely, so a scratch CWD affects nothing else. Scratch lives
+    under HERMES_HOME (guaranteed writable by the gateway uid) and is removed
+    after the run.
     """
+    scratch_base = os.environ.get("HERMES_HOME", "").strip() or None
     try:
-        proc = subprocess.run(
-            args, capture_output=True, text=True, timeout=timeout,
-        )
+        with tempfile.TemporaryDirectory(prefix=".u1_kit_scratch_",
+                                         dir=scratch_base) as scratch:
+            proc = subprocess.run(
+                args, capture_output=True, text=True, timeout=timeout,
+                cwd=scratch,
+            )
     except subprocess.TimeoutExpired:
         return {"_error": f"u1_kit_workflow timed out after {timeout:.0f}s"}
     except FileNotFoundError as exc:

--- a/adapters/hermes/tools/u1_kit_tool.py
+++ b/adapters/hermes/tools/u1_kit_tool.py
@@ -17,8 +17,9 @@ verified 8-piece pattern).
 Flow:
   1. LLM calls ``u1_kit(model_path="...")``.
   2. Handler invokes ``u1_kit_workflow.py --json-events`` as a subprocess.
-  3. Parses the ``kit_form`` event (need_input) from its stdout, extracts
-     ``form_schema`` + ``request_id``.
+  3. Parses the ``kit_form`` event (need_input) from its stdout, reads the
+     ``form_id`` + ``request_id`` and loads the persisted schema by id (the
+     event carries the id only, not the nested schema).
   4. Calls ``form_gateway.invoke_form(session_key, form_schema)`` — blocks
      until the operator submits via Telegram inline buttons (or the text
      fallback). The platform send + user-tap routing all happen via the
@@ -34,6 +35,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import shlex
 import subprocess
 import sys
@@ -70,6 +72,30 @@ DEFAULT_PYTHON = os.environ.get("U1_KIT_PYTHON", "").strip() or sys.executable
 
 # 25 min covers a slow multi-plate slice; analysis phase is seconds.
 SUBPROCESS_TIMEOUT_SEC = int(os.environ.get("U1_KIT_TIMEOUT_SEC", "1500"))
+
+
+_FORM_ID_RE = re.compile(r"^[A-Za-z0-9_-]{6,64}$")
+
+
+def _load_persisted_schema(form_id: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Load the schema the workflow persisted for ``form_id``.
+
+    The kit_form event carries only a flat ``form_id``. A 26B local model
+    can't reproduce the nested schema in a tool call, so the workflow persists
+    it to disk and passes the id. This tool drives the form itself, so it loads
+    the schema the same way the ``form`` tool's handler does. The strict id
+    pattern (matching the workflow's own) also blocks path traversal."""
+    fid = str(form_id or "")
+    if not _FORM_ID_RE.match(fid):
+        return None
+    base = os.environ.get("U1_FORM_SCHEMAS_DIR", "").strip() \
+        or "/opt/data/snapmaker_u1/form_schemas"
+    try:
+        with open(os.path.join(base, f"{fid}.json"), "r") as fh:
+            schema = json.load(fh)
+        return schema if isinstance(schema, dict) else None
+    except Exception:
+        return None
 
 
 def _run_workflow(args: List[str], *, timeout: float) -> Dict[str, Any]:
@@ -188,10 +214,16 @@ def u1_kit_tool(
 
     form_schema = kit_form.get("form_schema") or {}
     wf_request_id = kit_form.get("request_id") or request_id
-    if not isinstance(form_schema, dict) or not form_schema.get("fields"):
+    # The workflow emits kit_form with only a form_id (the full schema is
+    # persisted to disk, never carried through the event); load it by id, the
+    # same way the `form` tool's handler does, so this tool can drive the form.
+    if not (isinstance(form_schema, dict) and form_schema.get("fields")):
+        form_schema = _load_persisted_schema(kit_form.get("form_id")) or {}
+    if not (isinstance(form_schema, dict) and form_schema.get("fields")):
         return json.dumps({
             "phase": "analysis",
-            "error": "kit_form event missing valid form_schema",
+            "error": "kit_form event carried no form_schema and no persisted "
+                     "schema was found for its form_id",
             "kit_form": kit_form,
         }, ensure_ascii=False)
 

--- a/adapters/hermes/tools/u1_kit_tool.py
+++ b/adapters/hermes/tools/u1_kit_tool.py
@@ -308,17 +308,10 @@ U1_KIT_SCHEMA = {
 }
 
 
-# --- Registry ----------------------------------------------------------------
-from tools.registry import registry  # type: ignore
-
-registry.register(
-    name="u1_kit",
-    toolset="u1_kit",
-    schema=U1_KIT_SCHEMA,
-    handler=lambda args, **_kw: u1_kit_tool(
-        model_path=args.get("model_path", ""),
-        request_id=args.get("request_id") or None,
-    ),
-    check_fn=check_u1_kit_requirements,
-    emoji="🖨️",
-)
+# --- Registration --------------------------------------------------------------
+# NOT self-registered here: a tool dropped into tools/ registers but is never
+# OFFERED to the model (the platform toolset allowlist resolves by subset, which
+# a runtime-registered toolset can never satisfy). The u1-form plugin registers
+# u1_kit as its own OFFERED toolset via ctx.register_tool (see
+# adapters/hermes/plugin/__init__.py register()). This module just exposes the
+# handler (u1_kit_tool) + schema (U1_KIT_SCHEMA) + check (check_u1_kit_requirements).

--- a/adapters/hermes/tools/u1_kit_tool.py
+++ b/adapters/hermes/tools/u1_kit_tool.py
@@ -24,8 +24,10 @@ Flow:
      until the operator submits via Telegram inline buttons (or the text
      fallback). The platform send + user-tap routing all happen via the
      monkey-patched ``TelegramAdapter.send_form`` / ``_handle_callback_query``.
-  5. Re-invokes the workflow with ``--form-answers-json <answer>
-     --request-id <id>``.
+  5. Re-invokes the workflow to redeem the submitted answers and slice.
+     Kit forms submit in FILE mode (the gateway persists answers to disk and
+     hands back a write-receipt), so redemption reuses the workflow's own
+     next_command flags (``--redeem-pending-form`` + nozzle + ``--live-upload``).
   6. Returns the ``kit_readiness_card`` (request_id, plate count, gated
      plate, Stage 1 command) to the LLM.
 """
@@ -144,6 +146,36 @@ def _find_event(events: List[Dict[str, Any]], stage: str,
     return None
 
 
+def _phase3_flags(next_command: str, wf_request_id: str,
+                  answer: Dict[str, Any]) -> List[str]:
+    """Workflow flags that redeem the operator's submitted form answers.
+
+    U1 kit forms submit in FILE mode: on submit the gateway persists the
+    answers to disk and invoke_form hands back a write-receipt, NOT the answers
+    themselves, so they redeem via --redeem-pending-form (never the receipt as
+    JSON). The kit_form event's next_command is exactly the phase-3 command the
+    workflow authored for the (validated) model-driven path; reuse its flags
+    verbatim so the deterministic path runs the identical slice + upload,
+    carrying the detected --nozzle and --live-upload. Only python/script/model
+    paths are swapped for ours. Falls back to an explicit flag set if
+    next_command can't be parsed or carries no redemption flag."""
+    try:
+        toks = shlex.split(next_command or "")
+    except ValueError:
+        toks = []
+    # toks == [python, script.py, <model path>, <flags...>]; keep the flags.
+    flags = toks[3:] if len(toks) >= 4 else []
+    if any(f in ("--redeem-pending-form", "--form-answers-json") for f in flags):
+        return flags
+    out = ["--json-events", "--request-id", str(wf_request_id)]
+    if answer.get("_answers_file_written"):
+        out.append("--redeem-pending-form")
+    else:
+        out += ["--form-answers-json", json.dumps(answer, ensure_ascii=False)]
+    out.append("--live-upload")
+    return out
+
+
 def u1_kit_tool(
     model_path: str,
     *,
@@ -246,12 +278,13 @@ def u1_kit_tool(
         return json.dumps({"phase": "form_timeout", "request_id": wf_request_id},
                           ensure_ascii=False)
 
-    # --- Phase 3: re-invoke workflow with the answer ------------------------
-    cmd2 = [
-        python, workflow_script, str(path), "--json-events",
-        "--request-id", str(wf_request_id),
-        "--form-answers-json", json.dumps(answer, ensure_ascii=False),
-    ]
+    # --- Phase 3: redeem the operator's answers and slice -------------------
+    # File-submit forms hand back a write-receipt, not the answers, so redeem
+    # them via the flags the workflow authored in next_command (--redeem-
+    # pending-form + the detected nozzle + --live-upload), matching the
+    # validated model-driven path exactly. See _phase3_flags.
+    cmd2 = [python, workflow_script, str(path)] + _phase3_flags(
+        kit_form.get("next_command", ""), str(wf_request_id), answer)
     logger.info("u1_kit phase 3: %s",
                 " ".join(shlex.quote(a) for a in cmd2))
     res2 = _run_workflow(cmd2, timeout=timeout)

--- a/adapters/hermes/tools/u1_kit_tool.py
+++ b/adapters/hermes/tools/u1_kit_tool.py
@@ -160,6 +160,22 @@ def _find_event(events: List[Dict[str, Any]], stage: str,
     return None
 
 
+def _is_passthrough_event(ev: Dict[str, Any]) -> bool:
+    """Events u1_kit re-emits in its output so the gateway attach hook and the
+    model see them: the renders (plate previews + bed photo), the review doc,
+    the readiness card, and the bed-clear approval prompt.
+
+    The bed-clear prompt is ``stage="need_input"`` with ``key="bed_clear_start"``
+    (not a stage of its own), so it must be matched by key. A stage-only filter
+    dropped it, leaving the deterministic path with a readiness card but no YES
+    prompt, so the operator could never start the print. The phase-1 form prompt
+    (``key="kit_form"``) is deliberately NOT re-surfaced here."""
+    if ev.get("stage") in ("render", "review_doc", "kit_readiness_card"):
+        return True
+    return (ev.get("stage") == "need_input"
+            and ev.get("key") == "bed_clear_start")
+
+
 def _phase3_flags(next_command: str, wf_request_id: str,
                   answer: Dict[str, Any]) -> List[str]:
     """Workflow flags that redeem the operator's submitted form answers.
@@ -341,9 +357,8 @@ def u1_kit_tool(
     # stdout); this tool captured them into res2["events"], so it must re-emit
     # them here or the plate previews + bed photo + review doc never attach.
     _passthrough = "\n".join(
-        json.dumps(ev, ensure_ascii=False) for ev in res2["events"]
-        if ev.get("stage") in ("render", "review_doc", "kit_readiness_card",
-                               "bed_clear_start"))
+        json.dumps(ev, ensure_ascii=False)
+        for ev in res2["events"] if _is_passthrough_event(ev))
     _summary = json.dumps({
         "phase": "ready",
         "request_id": wf_request_id,

--- a/skills/3d-printer-slicing-automation/SKILL.md
+++ b/skills/3d-printer-slicing-automation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: 3d-printer-slicing-automation
-description: "REQUIRED for ANY .stl / .3mf / .zip 3D-model attachment. FIRST tool call MUST be: 'python3 /opt/data/scripts/u1_slice_workflow.py <attachment-path> --json-events'. The workflow handles zip inspection + slicing. Do NOT extract zips or run orca-slicer yourself. Also REQUIRED when the operator asks to reprint a recent job (no file attached) — follow the Reprint section."
-version: 2.3.4
+description: "REQUIRED for ANY .stl / .3mf / .zip 3D-model attachment. FIRST tool call MUST be the u1_kit tool: u1_kit(model_path=<attachment-path>). It slices, renders the operator's options form itself, and returns a readiness card. Do NOT extract zips, run orca-slicer, or call the form tool yourself. Also REQUIRED when the operator asks to reprint a recent job (no file attached): follow the Reprint section."
+version: 2.4.0
 author: Brent Bolinger / snapmaker-u1-toolkit
 license: MIT
 metadata:
@@ -21,27 +21,29 @@ prerequisites:
 
 This skill is a set of COMMANDS, not a description to summarize. If you catch yourself about to write a command, a plan, or JSON as your reply TEXT instead of calling a tool — stop, delete that text, call the tool instead. Printing `python3 ...` in your reply is not a tool call; it does nothing.
 
-**The moment a user gives you an STL/3MF/zip, your very next action is this tool call — no text before it:**
-```bash
-python3 /opt/data/scripts/u1_slice_workflow.py <model> --json-events
+**The moment a user gives you an STL/3MF/zip, your very next action is this tool call, no text before it:** call the **`u1_kit`** tool with the attachment path.
 ```
-(If the platform rejects raw `.stl` but accepts `.zip`, extract the STL first, then run this on the extracted path.) This one command is the entry for EVERYTHING — a single model or a multi-part kit zip alike; the workflow figures out which.
+u1_kit(model_path="<attachment path>")
+```
+This ONE call is the entry for EVERYTHING, a single model or a multi-part kit zip alike. It drives the whole job deterministically: it slices, shows the operator a native options form (inline buttons), collects the answers, and returns the readiness card. Do NOT run `u1_slice_workflow.py` or `u1_kit_workflow.py` by hand for a new job, and do NOT call the `form` tool yourself. `u1_kit` renders the form for you, so there is nothing to relay. (If the platform saved the attachment as a `.zip`, pass that path; if it saved a raw `.stl`, zip it first and pass the zip.)
 
-**Immediately after that first tool call**, your first TEXT reply (only once, not every turn) is:
-> "On it — running the Snapmaker U1 workflow. I'll surface every choice for you, show the plate preview and a fresh bed photo before anything prints, run only the commands the workflow gives me (never ones I invent), and nothing starts until you confirm at the bed-clear step."
+**Immediately after that call**, your first TEXT reply (only once, not every turn) is:
+> "On it, running the Snapmaker U1 workflow. I'll surface every choice for you, show the plate preview and a fresh bed photo before anything prints, and nothing starts until you confirm at the bed-clear step."
 
-**Then, every turn after that, follow this loop — no exceptions:**
+**`u1_kit` returns a JSON object with a `phase`. Act on it, no exceptions:**
 
-| The workflow's output has… | You do exactly this |
+| `u1_kit` `phase` | You do exactly this |
 |---|---|
-| `kit_detected` | CALL terminal with its `command` field, verbatim. That runs `u1_kit_workflow.py` (a single model = a kit of one). |
-| `kit_form` | CALL the `form` tool with its `form_id`. Nothing else — no text first. |
-| `need_input` (text fallback, no form) | Surface `prompt` + numbered options to the operator, wait for their answer, then CALL terminal with the matched option's `next_command`, verbatim. |
-| `next_action_required` | CALL terminal with its `command`, verbatim. No question, no preamble — the workflow already decided. |
+| `ready` | The kit sliced. The tool's output also carries the workflow's `render` (plate preview + isometric) and `review_doc` lines and a `kit_readiness_card`. Go to **Step 3**: surface those, then the bed-clear prompt. |
+| `form_rejected` | An answer did not validate. Call `u1_kit(model_path="...", request_id="<the id it returned>")` again to retry. |
+| `cancelled` | The operator cancelled the form. Tell them, then stop. |
+| `form_timeout` | The form expired unanswered. Tell them, and offer to re-call `u1_kit`. |
+| `setup_required` | Surface the `message` verbatim (it names a setup script). Do not proceed. |
+| any `error` | Surface the error text (and the `stderr` tail if present). Do not invent a recovery. |
 
 **Never**: edit a command before relaying it, add or drop a flag, construct a command yourself from memory of an earlier turn, or invent a magic confirmation phrase. The workflow is the only source of truth for what runs next — if it didn't hand you the string this turn, you don't have it.
 
-**Step 2 (staged text fallback) — for each `need_input` event (text fallback only; form mode is one screen).**
+**Step 2 (FALLBACK ONLY, skip this whenever `u1_kit` worked).** Use this path only if the `u1_kit` tool is not offered to you at all. Then, and only then, run the workflow yourself: `python3 /opt/data/scripts/u1_slice_workflow.py <model> --json-events`, relay each `kit_detected`/`next_action_required` `command` verbatim via terminal, and for each `need_input` text event (no native form on this platform):
 
 Order: `parts` (skipped for a single model) → `orient` → `tool` → `preset` → `supports` → `confirm`. (Follow whatever order the workflow actually emits — this is just what to expect.)
 

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -240,3 +240,23 @@ def test_kit_tool_spawns_workflow_in_writable_cwd(monkeypatch):
     monkeypatch.setattr(tool.subprocess, "run", fake_run)
     tool._run_workflow(["x"], timeout=5)
     assert captured.get("cwd")
+
+
+def test_kit_tool_passthrough_includes_bed_clear_prompt():
+    """u1_kit must re-emit the bed-clear approval prompt in its output.
+
+    Regression (self-test, 2026-07-13): the prompt is stage=need_input,
+    key=bed_clear_start (not a stage of its own). A stage-only filter dropped
+    it, so the deterministic path returned the readiness card but no YES prompt
+    and the operator could never start the print.
+    """
+    keep = _load_kit_tool()._is_passthrough_event
+    # attach + card + the YES prompt all pass through
+    assert keep({"stage": "render"})
+    assert keep({"stage": "review_doc"})
+    assert keep({"stage": "kit_readiness_card"})
+    assert keep({"stage": "need_input", "key": "bed_clear_start"})
+    # the phase-1 form prompt must NOT re-surface, nor internal control events
+    assert not keep({"stage": "need_input", "key": "kit_form"})
+    assert not keep({"stage": "kit_slicing"})
+    assert not keep({"stage": "awaiting_input", "need": "bed_clear_start"})

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -260,3 +260,29 @@ def test_kit_tool_passthrough_includes_bed_clear_prompt():
     assert not keep({"stage": "need_input", "key": "kit_form"})
     assert not keep({"stage": "kit_slicing"})
     assert not keep({"stage": "awaiting_input", "need": "bed_clear_start"})
+
+
+def test_kit_tool_recovers_mangled_upload_path(tmp_path):
+    """u1_kit must recover a model-mangled upload name by its doc_<hash> prefix.
+
+    Regression (live 2026-07-13): gemma retyped the cached zip name, turning a
+    '+' into '_' (Bar+Skadis -> Bar_Skadis). u1_kit's strict existence check
+    bailed with 'model not found' before the workflow's #45 recovery could run.
+    """
+    from pathlib import Path as _P
+    tool = _load_kit_tool()
+    real = tmp_path / "doc_e26dff8c8ada_Phillips+Hue+Play+Bar+Skadis_stls.zip"
+    real.write_bytes(b"zip")
+    mangled = tmp_path / "doc_e26dff8c8ada_Phillips+Hue+Play+Bar_Skadis_stls.zip"
+    assert not mangled.exists()
+    assert tool._resolve_upload_path(_P(mangled)) == real
+    # an exact, existing path passes through untouched
+    assert tool._resolve_upload_path(_P(real)) == real
+    # a non-doc name or no match is returned unchanged (no false recovery)
+    missing = tmp_path / "random_name.zip"
+    assert tool._resolve_upload_path(_P(missing)) == missing
+    # ambiguous prefix (two files) is left alone, never guessed
+    (tmp_path / "doc_abc123_one.zip").write_bytes(b"1")
+    (tmp_path / "doc_abc123_two.zip").write_bytes(b"2")
+    amb = tmp_path / "doc_abc123_x.zip"
+    assert tool._resolve_upload_path(_P(amb)) == amb

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -209,3 +209,34 @@ def test_kit_tool_phase3_redeems_file_submitted_answers():
     # A genuine inline answer (no file receipt) may pass through as JSON.
     inline = tool._phase3_flags("", "rid", {"parts": [1, 2], "tool": "extruder"})
     assert "--form-answers-json" in inline
+
+
+def test_kit_tool_spawns_workflow_in_writable_cwd(monkeypatch):
+    """_run_workflow must spawn the workflow with an explicit, writable cwd, not
+    inherit the gateway's.
+
+    Regression (live drill 3, 2026-07-13): Orca writes 00000.log to the process
+    CWD; the gateway CWD (/opt/hermes) is not writable, so inheriting it crashed
+    the slice with a filesystem I/O error. The spawn must set cwd to a scratch
+    dir that exists and is writable at call time.
+    """
+    import os as _os
+    tool = _load_kit_tool()
+    captured = {}
+
+    class _Proc:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(args, **kw):
+        captured.update(kw)
+        cwd = kw.get("cwd")
+        assert cwd, "workflow spawned without an explicit cwd"
+        assert _os.path.isdir(cwd) and _os.access(cwd, _os.W_OK), \
+            "scratch cwd must exist and be writable during the run"
+        return _Proc()
+
+    monkeypatch.setattr(tool.subprocess, "run", fake_run)
+    tool._run_workflow(["x"], timeout=5)
+    assert captured.get("cwd")

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -11,6 +11,7 @@ The two copies of that chain are asserted here so they can't drift.
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 import types
 from pathlib import Path
@@ -141,3 +142,35 @@ def test_gate_exports_notify_py_to_notify_script(monkeypatch, tmp_path):
     assert res["ok"], res
     dumped = capture.read_text()
     assert f"U1_NOTIFY_PY={_ROOT / 'scripts' / 'u1_notify.py'}" in dumped
+
+
+def test_kit_tool_loads_persisted_schema_by_id(monkeypatch, tmp_path):
+    """u1_kit must load the form schema the workflow persisted to disk by its
+    form_id.
+
+    Regression (live drill 2026-07-13): the kit_form event carries only a
+    form_id (the nested schema is persisted separately because a 26B local
+    model can't reproduce it in a tool call). The tool used to expect the
+    schema INLINE, bailed with 'missing valid form_schema', and the model fell
+    back to a hand-emitted form() call, the exact garble path this feature
+    removes. The loader must mirror the u1-form plugin's, including the strict
+    id pattern that also blocks path traversal.
+    """
+    tool = _load_kit_tool()
+    schemas = tmp_path / "form_schemas"
+    schemas.mkdir()
+    fid = "f7d010b6ce2"
+    (schemas / f"{fid}.json").write_text(
+        json.dumps({"version": 1,
+                    "fields": [{"id": "parts"}, {"id": "tool"}]}))
+    monkeypatch.setenv("U1_FORM_SCHEMAS_DIR", str(schemas))
+
+    loaded = tool._load_persisted_schema(fid)
+    assert isinstance(loaded, dict) and loaded.get("fields"), \
+        "schema persisted for a valid form_id must load"
+    # Malformed / traversal / missing ids are refused, never raise.
+    assert tool._load_persisted_schema("../../etc/passwd") is None
+    assert tool._load_persisted_schema("bad id!") is None
+    assert tool._load_persisted_schema("") is None
+    assert tool._load_persisted_schema(None) is None
+    assert tool._load_persisted_schema("fbbbbbbbbbb") is None  # valid id, no file

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -174,3 +174,38 @@ def test_kit_tool_loads_persisted_schema_by_id(monkeypatch, tmp_path):
     assert tool._load_persisted_schema("") is None
     assert tool._load_persisted_schema(None) is None
     assert tool._load_persisted_schema("fbbbbbbbbbb") is None  # valid id, no file
+
+
+def test_kit_tool_phase3_redeems_file_submitted_answers():
+    """Kit forms submit in file mode: invoke_form returns a write-receipt, not
+    the answers.
+
+    Regression (live drill 2, 2026-07-13): u1_kit passed that receipt to the
+    slicer as --form-answers-json, so it validated as empty and bounced with
+    "missing required field: tool/material/profile", re-rendering the form in a
+    loop. Phase 3 must redeem the answers from disk using the workflow's own
+    next_command flags (--redeem-pending-form + detected nozzle + --live-upload),
+    never the receipt.
+    """
+    tool = _load_kit_tool()
+    receipt = {"_answers_file_written": True, "form_id": "f7d010b6ce2",
+               "path": "/opt/data/snapmaker_u1/answers/f7d010b6ce2.json"}
+    next_cmd = ("python3 /opt/data/scripts/u1_kit_workflow.py "
+                "'/opt/data/cache/documents/doc_x_stls.zip' --json-events "
+                "--request-id u1_2026_0714_a5df11 --nozzle 0.4 "
+                "--redeem-pending-form --live-upload")
+    flags = tool._phase3_flags(next_cmd, "u1_2026_0714_a5df11", receipt)
+    # the receipt must NEVER be serialized into the slice command
+    assert "--form-answers-json" not in flags
+    assert "--redeem-pending-form" in flags
+    assert "--live-upload" in flags
+    assert flags[:3] == ["--json-events", "--request-id", "u1_2026_0714_a5df11"]
+    assert "0.4" in flags  # the workflow-detected nozzle is carried through
+
+    # Fallback when next_command is unparseable: a file-receipt still redeems
+    # from disk, never as JSON.
+    fb = tool._phase3_flags("", "u1_2026_0714_a5df11", receipt)
+    assert "--redeem-pending-form" in fb and "--form-answers-json" not in fb
+    # A genuine inline answer (no file receipt) may pass through as JSON.
+    inline = tool._phase3_flags("", "rid", {"parts": [1, 2], "tool": "extruder"})
+    assert "--form-answers-json" in inline


### PR DESCRIPTION
## v2.4.3: the kit options form is driven by the toolkit, not the model

When you send a kit, the toolkit now renders the options form, collects the
answers, slices, and returns the readiness card as one deterministic step. The
model no longer has to request the form itself (a small local model would
sometimes garble that request and stall the job), so that failure mode is gone.
The plate previews, bed photo, review document, and the bed-clear approval all
flow through unchanged, and the safety gate is untouched.

### What is in it

- The kit tool drives the form from end to end (renders, collects answers,
  slices, returns the readiness card); the model is out of the form loop.
- Four issues found while proving it out on real hardware and with an offline
  operator harness: the form schema is loaded by its stored id, file-submitted
  answers are redeemed from disk rather than a receipt, the slice runs from a
  writable working directory, and the bed-clear approval prompt is carried
  through to the operator.
- A mistyped upload name is recovered by its stable id before the job gives up.
- The first taps on a freshly shown form register (a fast tap could beat the
  form's registration and flash without checking the box).

### Validation

- Full test suite green (1002 passed).
- Proven end to end on real hardware: a single deterministic call, the form, the
  slice, the readiness card, operator approval, and a grace-window cancel.
- Also validated offline with a harness that drives the real tool with a
  scripted operator, which is what caught the bed-clear-prompt gap before it
  shipped.

See CHANGELOG.md for the user-facing summary.
