### PR TITLE
v2.4.4: kit form shows the filament that's loaded right now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2.4.4] — 2026-07-14
+
+### Fixed
+
+- **The kit options screen now shows the filament that is loaded right now.** The
+  tool and filament picker read a snapshot of the loaded spools that was only
+  refreshed when a print started or a file was uploaded. If you swapped a spool
+  (colour or material) between jobs, the next kit's picker could still show the
+  previous spool, such as an old colour, even though the printer already knew
+  about the change. The picker now reads the printer's current filament at the
+  moment it builds the screen, so what you see matches what is loaded. If the
+  printer cannot be reached for a moment, it falls back to the last known
+  snapshot rather than showing nothing. The start-time safety check already read
+  the live state and was never affected.
+
+---
+
 ## [2.4.3] — 2026-07-13
 
 The kit options form is now driven by the toolkit itself, from end to end. It is

--- a/scripts/u1_kit_workflow.py
+++ b/scripts/u1_kit_workflow.py
@@ -1684,7 +1684,9 @@ def _emit_parts_prompt(events_file: Path | None, request_id: str, archive: Path,
     try:
         _existing = u1_request.read_request(request_id) or {}
         if not _existing.get("form_profiles"):
-            _spec_for_persist = _build_form_spec(kit, nozzle)
+            # Only the profile list is used here; heads aren't rendered, so skip
+            # the live printer query (the emit path below refreshes for real).
+            _spec_for_persist = _build_form_spec(kit, nozzle, refresh=False)
             if _spec_for_persist.get("_profiles_full"):
                 u1_request.write_request(
                     request_id,
@@ -1991,7 +1993,8 @@ def _audit(request_id: str, event: str, operator: str, **details: Any):
 
 
 def _build_form_spec(kit: dict[str, Any], nozzle: str,
-                     persisted_profiles: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+                     persisted_profiles: list[dict[str, Any]] | None = None,
+                     refresh: bool = True) -> dict[str, Any]:
     """Assemble the u1_form spec from analysis (parts + offered options).
 
     ``profile N`` is resolved by INDEX, and form-emit / answer-parse happen in
@@ -2023,6 +2026,15 @@ def _build_form_spec(kit: dict[str, Any], nozzle: str,
     # to generic T0–T3 + a Material screen (offline / tests).
     try:
         import u1_toolmap
+        # Pull the printer's CURRENT loaded filament before reading the tool map,
+        # so a spool swapped since the last gate/upload run isn't shown stale on
+        # the head screen (live 2026-07-14: the picker kept the previous run's
+        # colour after a swap the printer already reported). Guarded inside
+        # refresh_toolmap: an unreachable printer leaves the existing cache in
+        # place. Skipped (refresh=False) on the post-submit re-validate path and
+        # in unit tests, where no picker is shown and no printer is present.
+        if refresh:
+            u1_toolmap.refresh_toolmap()
         heads = u1_toolmap.load_head_options()
     except Exception:
         heads = []
@@ -5239,8 +5251,12 @@ def _run_legacy_form_answers(args, operator: str, archive: Path,
     --form-answers-from <form_id> (v2.2 file handoff — the gateway wrote
     the answers; the model never carried them)."""
     existing = u1_request.read_request(request_id) or {}
+    # Post-submit re-validate: the operator already picked from the (fresh-at-
+    # emit) form, and the start gate does its own live material check, so no
+    # need to re-query the printer here.
     spec = _build_form_spec(kit, getattr(args, "nozzle", "0.4"),
-                            persisted_profiles=existing.get("form_profiles"))
+                            persisted_profiles=existing.get("form_profiles"),
+                            refresh=False)
     if not spec["profiles"]:
         _emit(events_file, {"stage": "setup_required", "kind": "no_profiles",
                             "message": "No profiles found. Run tools/fetch_snapmaker_profiles.py."},

--- a/scripts/u1_toolmap.py
+++ b/scripts/u1_toolmap.py
@@ -33,6 +33,35 @@ CHANNEL_EXTRUDER = {v: k for k, v in EXTRUDER_CHANNEL.items()}
 _UNKNOWN_MATERIALS = {"", "UNKNOWN", "NONE"}
 
 
+def refresh_toolmap(data_dir: Path | None = None, host: str | None = None,
+                    port: int | None = None, timeout: float = 8.0) -> bool:
+    """Query the printer LIVE and rewrite ``latest_toolmap.json``.
+
+    That cache is what the form reads (via ``load_head_options``), but it is
+    otherwise only rewritten when this module runs as a CLI (the start gate +
+    upload path). So the form built at the START of a job reflects the PREVIOUS
+    run's filament snapshot: a spool swapped between jobs reads stale (live
+    2026-07-14, Brent: the head screen showed the old 'orange' after a swap
+    while the printer already reported the new spool). Refreshing here makes the
+    head screen show the CURRENT loaded filament. The declared material_map
+    overlay is preserved (summarize merges it). Fully guarded: returns True on a
+    live refresh, False if the printer is unreachable or anything fails, in
+    which case callers fall through to the existing cache / generic fields."""
+    try:
+        h = host or get_u1_host()
+        p = port if port is not None else get_u1_port()
+        outdir = data_dir or get_data_dir()
+        material_map = load_material_map(_default_map_path())
+        raw = query_u1(h, int(p), timeout)
+        summary = summarize(raw, material_map, None, None)
+        outdir.mkdir(parents=True, exist_ok=True)
+        (outdir / "latest_toolmap.json").write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n")
+        return True
+    except Exception:
+        return False
+
+
 def load_head_options(data_dir: Path | None = None) -> list[dict[str, Any]]:
     """Read ``latest_toolmap.json`` → ordered list of LOADED print heads, each
     with its live material + colour, so a form can merge "which head?" and

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -481,8 +481,13 @@ def test_plugin_registers_form_tool_and_dispatch_hook(monkeypatch, tmp_path):
     mod = _load_plugin_pkg(monkeypatch, tmp_path)
     ctx = _FakeCtx()
     mod.register(ctx)
-    (tool,) = ctx.tools
-    assert tool["name"] == "form"
+    # The plugin always registers `form`; it ALSO registers the deterministic
+    # `u1_kit` tool when tools.u1_kit_tool is importable (present in a full
+    # install / on-box venv, absent in CI's isolated plugin load). Select `form`
+    # explicitly rather than assuming it is the only registered tool.
+    tools_by_name = {t["name"]: t for t in ctx.tools}
+    assert set(tools_by_name) <= {"form", "u1_kit"}, tools_by_name
+    tool = tools_by_name["form"]
     assert tool["toolset"] == "form"  # own toolset — the plugin path is what
     # surfaces it; joining clarify would evict clarify via subset-inference
     assert callable(tool["handler"])

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -56,10 +56,32 @@ def _kit(n):
 
 def test_workflow_offers_quantity_only_for_single_part():
     profs = [{"idx": 1, "value": "0_20_standard", "label": "0.20 Standard"}]
-    single = kw._build_form_spec(_kit(1), "0.4", persisted_profiles=profs)
+    # refresh=False: this exercises offer_quantity logic, not the live printer.
+    single = kw._build_form_spec(_kit(1), "0.4", persisted_profiles=profs, refresh=False)
     assert single.get("offer_quantity") is True
-    multi = kw._build_form_spec(_kit(3), "0.4", persisted_profiles=profs)
+    multi = kw._build_form_spec(_kit(3), "0.4", persisted_profiles=profs, refresh=False)
     assert "offer_quantity" not in multi
+
+
+def test_build_form_spec_refreshes_toolmap_before_render(monkeypatch):
+    """The render path must pull the printer's LIVE filament before reading the
+    tool map, so a spool swapped between jobs isn't shown stale on the head
+    screen (bug 2026-07-14). The persist / re-validate paths pass refresh=False
+    and must NOT query the printer."""
+    import u1_toolmap
+    profs = [{"idx": 1, "value": "0_20_standard", "label": "0.20 Standard"}]
+    calls = {"n": 0}
+
+    def _count(*a, **k):
+        calls["n"] += 1
+        return True
+
+    monkeypatch.setattr(u1_toolmap, "refresh_toolmap", _count)
+    monkeypatch.setattr(u1_toolmap, "load_head_options", lambda *a, **k: [])
+    kw._build_form_spec(_kit(1), "0.4", persisted_profiles=profs)  # refresh=True default
+    assert calls["n"] == 1, "render path must refresh before reading the tool map"
+    kw._build_form_spec(_kit(1), "0.4", persisted_profiles=profs, refresh=False)
+    assert calls["n"] == 1, "refresh=False must not query the printer"
 
 
 # ---------- schema ----------

--- a/tests/test_u1_toolmap.py
+++ b/tests/test_u1_toolmap.py
@@ -174,6 +174,34 @@ def test_load_head_options_missing_toolmap_returns_empty(tmp_path):
     assert u1_toolmap.load_head_options(data_dir=tmp_path) == []
 
 
+# --------------------------------------------------------------------------- #
+# refresh_toolmap — the form-build path pulls the printer's LIVE filament before
+# reading the tool map, so a spool swapped BETWEEN jobs isn't served stale. Live
+# bug 2026-07-14: the head screen showed the previous run's colour ("orange")
+# after a swap the printer already reported, because the cache was only rewritten
+# by the gate / upload CLI, never at form-build time. Could mislead an operator
+# into printing the wrong material — safety-relevant, hence the regression
+# coverage. load_head_options itself stays a pure cache read (tested above); the
+# refresh is invoked by _build_form_spec (see test_quantity).
+# --------------------------------------------------------------------------- #
+
+def test_refresh_toolmap_writes_live_snapshot_and_is_guarded(tmp_path, monkeypatch):
+    """refresh_toolmap queries the printer and rewrites the cache; on any failure
+    it returns False without raising, so load_head_options can fall back."""
+    monkeypatch.setattr(u1_toolmap, "query_u1", lambda *a, **k: _fake_printer_raw())
+    monkeypatch.setattr(u1_toolmap, "get_u1_host", lambda: "x")
+    monkeypatch.setattr(u1_toolmap, "get_u1_port", lambda: 1)
+    monkeypatch.setattr(u1_toolmap, "_default_map_path", lambda: tmp_path / "map.json")
+    assert u1_toolmap.refresh_toolmap(data_dir=tmp_path) is True
+    written = json.loads((tmp_path / "latest_toolmap.json").read_text())
+    assert "tools" in written
+    # guarded: a query failure returns False, no exception escapes
+    def _boom(*a, **k):
+        raise OSError("unreachable")
+    monkeypatch.setattr(u1_toolmap, "query_u1", _boom)
+    assert u1_toolmap.refresh_toolmap(data_dir=tmp_path) is False
+
+
 # ── Enforcement-layer tests (2026-07-05) ─────────────────────────────────────
 # The tests above verify summarize() DETECTS gates. But the live bug was that
 # main() returned exit 0 REGARDLESS of gates, and run_tool_gate() keys purely on


### PR DESCRIPTION
## What this fixes

The kit options form shows the current filament and colour for each head. That data came from a snapshot that was only refreshed when a print started or a file was uploaded, so swapping a spool between jobs could leave the next kit's picker showing the previous spool (for example an old colour) even though the printer already knew about the change.

The picker now reads the printer's current filament at the moment it builds the screen. If the printer can't be reached for a moment it falls back to the last known snapshot rather than showing nothing. The start-time safety check already read the live state and is unchanged.

## Changes

- Pull the live tool map in the form-build path (`_build_form_spec`); the profile-persist and post-submit re-validate paths skip the query.
- `load_head_options` stays a pure cache read; new `refresh_toolmap()` does the guarded live pull.
- Regression tests: the refresh writes a live snapshot and is guarded, and the render path refreshes while the opt-out paths do not.
- Makes an environment-brittle plugin-registration test tolerate the optional u1_kit tool (it failed only on a full install, not in CI).

## Verification

Poisoned the on-disk cache with a stale value and confirmed the deployed form-build path returns the printer's live filament instead. Full suite: 1007 passed, 8 skipped.
