### PR TITLE
v2.5.0: profiles from your recent prints + last-used default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2.5.0] — 2026-07-14
+
+### Added
+
+- **Profiles from your recent prints.** The print-profile picker now offers
+  profiles pulled automatically from what you have actually printed, not just the
+  bundled Snapmaker presets. When you send a kit, the toolkit reads the settings
+  from your recent prints on the printer and offers them as selectable profiles,
+  named the way your slicer named them. It fetches only the small settings block
+  from each print, never the whole G-code, so a large print costs about a 1 MB
+  transfer instead of the full file. Reprints of the same object collapse to a
+  single entry, and a captured print that matches a profile you already have is
+  shown once.
+
+### Changed
+
+- **The kit options form pre-selects the profile you last printed with.** Instead
+  of opening with no profile chosen, the form now starts on your most recently
+  used profile, so a normal print is one tap shorter. You can still change it.
+
+---
+
 ## [2.4.4] — 2026-07-14
 
 ### Fixed

--- a/scripts/u1_form.py
+++ b/scripts/u1_form.py
@@ -917,9 +917,16 @@ def build_form_schema(spec: dict[str, Any], *, submit: dict[str, str] | None = N
                        "default": "1", "required": False})
     profiles = spec.get("profiles", [])
     if profiles:
-        fields.append({"id": "profile", "type": "single_select", "label": "Print profile",
-                       "options": [{"id": p.get("idx"), "label": _clean_label(_strip_profile_suffix(p.get("label")))} for p in profiles],
-                       "required": True})
+        _pfield = {"id": "profile", "type": "single_select", "label": "Print profile",
+                   "options": [{"id": p.get("idx"), "label": _clean_label(_strip_profile_suffix(p.get("label")))} for p in profiles],
+                   "required": True}
+        # Pre-select the picker's recommended profile (the operator's last-used,
+        # from print_history) so the form starts on it instead of unselected —
+        # the operator taps only to change it.
+        _rec = next((p for p in profiles if p.get("recommended")), None)
+        if _rec is not None and _rec.get("idx") is not None:
+            _pfield["default"] = _rec["idx"]
+        fields.append(_pfield)
     # Advanced overrides (v2.3): optional, EXCLUDED from the main screen flow —
     # the renderer only reaches them via the Review screen's Advanced button.
     # "default" = no override; skipping the screen is today's behavior.

--- a/scripts/u1_kit_workflow.py
+++ b/scripts/u1_kit_workflow.py
@@ -175,6 +175,7 @@ from u1_slice_workflow import (
     _shell_quote,
     _real_upload,
     list_profiles,
+    last_used_print_settings_id,
     profile_path,
     apply_supports_override,
     apply_profile_overrides,
@@ -1992,9 +1993,33 @@ def _audit(request_id: str, event: str, operator: str, **details: Any):
         return None
 
 
+# How many of the printer's most-recent prints to scan for new profiles at
+# form-build. Incremental (already-extracted prints are skipped), so after the
+# first run this is usually a no-op or a single ~1 MB head+tail fetch.
+_FROM_PRINTER_SCRUB_LIMIT = 8
+
+
+def _scrub_recent_prints() -> None:
+    """Populate ``profiles/from-printer/`` from the printer's recent prints so an
+    operator's actual prints appear as selectable profiles. Fetches only each
+    G-code's head+tail (settings), never the geometry; incremental; fully
+    GUARDED — any failure (printer off, import issue) leaves existing profiles
+    untouched. Lives in tools/, reached by adding it to sys.path at call time."""
+    try:
+        import os
+        _tools = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "tools")
+        if _tools not in sys.path:
+            sys.path.insert(0, _tools)
+        import extract_profiles_from_printer as _ep
+        _ep.refresh_from_printer(limit=_FROM_PRINTER_SCRUB_LIMIT)
+    except Exception:
+        pass
+
+
 def _build_form_spec(kit: dict[str, Any], nozzle: str,
                      persisted_profiles: list[dict[str, Any]] | None = None,
-                     refresh: bool = True) -> dict[str, Any]:
+                     refresh: bool = True, scrub: bool = True) -> dict[str, Any]:
     """Assemble the u1_form spec from analysis (parts + offered options).
 
     ``profile N`` is resolved by INDEX, and form-emit / answer-parse happen in
@@ -2007,13 +2032,32 @@ def _build_form_spec(kit: dict[str, Any], nozzle: str,
     """
     if persisted_profiles:
         profiles_full = [
-            {"idx": int(p["idx"]), "value": p["value"], "label": p.get("label", p["value"])}
+            {"idx": int(p["idx"]), "value": p["value"], "label": p.get("label", p["value"]),
+             "recommended": bool(p.get("recommended"))}
             for p in persisted_profiles
         ]
     else:
-        prof_opts = list_profiles(nozzle=nozzle)
+        # Building the profile list fresh -> first pull the operator's recent
+        # prints off the printer into profiles/from-printer/ so what they've
+        # actually printed shows up as a selectable profile (newest pre-selected
+        # below). Fetches only each G-code's head+tail (settings), never the
+        # geometry, and skips already-extracted prints, so it's cheap. Fully
+        # guarded. Skipped (scrub=False) in unit tests / the re-validate path.
+        if scrub:
+            _scrub_recent_prints()
+        # Tell the picker the operator's last-used preset (from print_history) so
+        # it marks + floats the one they actually printed with; the form then
+        # pre-selects it (build_form_schema reads "recommended"). tool=None -> the
+        # single most-recent across all tools, since the tool is chosen in this
+        # same form. Guarded: no history / unreadable -> plain scoring order.
+        try:
+            _last_used = last_used_print_settings_id(tool=None, nozzle=nozzle)
+        except Exception:
+            _last_used = None
+        prof_opts = list_profiles(nozzle=nozzle, history_print_settings_id=_last_used)
         profiles_full = [
-            {"idx": i + 1, "value": o["value"], "label": o.get("label", o["value"])}
+            {"idx": i + 1, "value": o["value"], "label": o.get("label", o["value"]),
+             "recommended": bool(o.get("recommended"))}
             for i, o in enumerate(prof_opts)
         ]
     parts = [
@@ -2042,7 +2086,8 @@ def _build_form_spec(kit: dict[str, Any], nozzle: str,
         "parts": parts,
         "tools": DEFAULT_TOOLS,
         "materials": DEFAULT_MATERIALS,
-        "profiles": [{"idx": p["idx"], "label": p["label"]} for p in profiles_full],
+        "profiles": [{"idx": p["idx"], "label": p["label"],
+                      "recommended": p.get("recommended", False)} for p in profiles_full],
         "supports": ["supports", "no-supports"],
         "actions": ["start", "upload-only"],
         "_prof_opts": [{"value": p["value"]} for p in profiles_full],  # idx -> resolution
@@ -5256,7 +5301,7 @@ def _run_legacy_form_answers(args, operator: str, archive: Path,
     # need to re-query the printer here.
     spec = _build_form_spec(kit, getattr(args, "nozzle", "0.4"),
                             persisted_profiles=existing.get("form_profiles"),
-                            refresh=False)
+                            refresh=False, scrub=False)
     if not spec["profiles"]:
         _emit(events_file, {"stage": "setup_required", "kind": "no_profiles",
                             "message": "No profiles found. Run tools/fetch_snapmaker_profiles.py."},

--- a/scripts/u1_profile_picker.py
+++ b/scripts/u1_profile_picker.py
@@ -98,12 +98,20 @@ def _scan_dir(source_label: str, source_dir: Path) -> list[dict]:
         if not _is_process_profile(path):
             continue
         pid = profile_id(path)
+        # from-printer profiles are named after the source G-code file; show the
+        # profile's OWN name (its print_settings_id) instead so the picker reads
+        # "0.20 Strength Gyroid", not "Phillips_Hue_..._process". `value` stays
+        # file-derived so profile resolution is unchanged.
+        label = path.stem
+        if source_label == 'from-printer':
+            label = _extracted_profile_label(path) or path.stem
         opts.append({
-            'label': path.stem,
+            'label': label,
             'value': pid,
             'path': str(path),
             'source': source_label,
             'has_supports': _read_supports_flag(path),
+            'mtime': _safe_mtime(path),
         })
     return opts
 
@@ -173,6 +181,67 @@ def _strip_decorations(s: str) -> str:
     if at_idx > 0:
         out = out[:at_idx]
     return out.strip()
+
+
+def _safe_mtime(path: Path) -> float:
+    try:
+        return path.stat().st_mtime
+    except Exception:
+        return 0.0
+
+
+def _clean_extracted_name(name: str) -> str:
+    """Human-facing form of an extracted profile's print_settings_id: strip a
+    leading Community/Hermes/Custom word and the ' @<printer>' suffix, keep case.
+    'Community 0.20 Strength Gyroid @Snapmaker U1 Textured PEI' -> '0.20 Strength
+    Gyroid'."""
+    out = name.strip()
+    low = out.lower()
+    for pfx in _HISTORY_DECORATION_PREFIXES:
+        if low.startswith(pfx):
+            out = out[len(pfx):]
+            break
+    at = out.find(' @')
+    if at > 0:
+        out = out[:at]
+    return out.strip() or name.strip()
+
+
+def _extracted_profile_label(path: Path) -> str | None:
+    """Display name for a from-printer profile: the process profile's own `name`
+    (its print_settings_id), cleaned. None if unreadable → caller falls back to
+    the file stem."""
+    try:
+        data = json.loads(path.read_text(encoding='utf-8'))
+    except Exception:
+        return None
+    name = data.get('name') or data.get('print_settings_id')
+    if isinstance(name, str) and name.strip():
+        return _clean_extracted_name(name.strip())
+    return None
+
+
+def _dedupe_by_name(opts: list[dict], source_priority: dict[str, int]) -> list[dict]:
+    """Collapse profiles that resolve to the same NAME to one entry. Covers two
+    cases: (1) from-printer reprints of the same object (many timestamps), and
+    (2) a captured print whose name matches a hand-saved user profile or a stock
+    one. Keep the highest-priority source (from-printer > user > stock), newest as
+    tiebreak — so the picker never shows the same profile twice. Distinct names
+    (e.g. '0.20 Strength' vs '0.20 Strength Gyroid') are untouched."""
+    best: dict[str, dict] = {}
+    order: list[str] = []
+    for o in opts:
+        key = _strip_decorations(str(o.get('label', '')).lower())
+        cur = best.get(key)
+        if cur is None:
+            best[key] = o
+            order.append(key)
+            continue
+        cp = (source_priority.get(o.get('source'), 99), -float(o.get('mtime', 0)))
+        pp = (source_priority.get(cur.get('source'), 99), -float(cur.get('mtime', 0)))
+        if cp < pp:
+            best[key] = o
+    return [best[k] for k in order]
 
 
 def _extract_layer_height_mm(label: str) -> float | None:
@@ -314,6 +383,13 @@ def list_profiles(profile_dir: Path | None = None,
                     continue
                 seen_values.add(opt['value'])
                 opts.append(opt)
+
+    # Collapse profiles that resolve to the same name to one entry (from-printer
+    # reprints, and a captured print matching a saved user/stock profile), with
+    # the highest-priority source kept — the picker never shows a profile twice.
+    _srcpri = {label: i for i, (label, _) in enumerate(sources or DEFAULT_SOURCES)}
+    _srcpri['legacy'] = 0
+    opts = _dedupe_by_name(opts, _srcpri)
 
     if nozzle:
         opts = [o for o in opts if _nozzle_matches(o['label'], nozzle)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -282,3 +282,19 @@ def _no_real_operator_notifications(monkeypatch, tmp_path):
     monkeypatch.setitem(sys.modules, "u1_notify", fake)
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "")
     monkeypatch.setenv("HERMES_BIN", "/bin/true")
+
+
+@pytest.fixture(autouse=True)
+def _no_printer_profile_scrub(monkeypatch):
+    """The from-printer profile scrub (form-build) reaches the real printer and
+    writes into the live profiles/from-printer/ dir. It must NEVER run under the
+    suite: on a box it would pollute live profiles, and the test host
+    (192.0.2.1, TEST-NET-1) is a black hole so it would hang on connect.
+    Production calls it for real; a test that wants to exercise it patches its
+    own stub (last-in wins)."""
+    try:
+        import u1_kit_workflow as _kw
+        monkeypatch.setattr(_kw, "_scrub_recent_prints",
+                            lambda *a, **k: None, raising=False)
+    except Exception:
+        pass

--- a/tests/test_extract_profiles_from_printer.py
+++ b/tests/test_extract_profiles_from_printer.py
@@ -201,3 +201,69 @@ def test_main_empty_printer_returns_3(monkeypatch, capsys):
     monkeypatch.setenv("SNAPMAKER_U1_HOST", "192.168.1.100")
     rc = epfp.main(["--list"])
     assert rc == 3
+
+
+# ── head+tail range download + incremental refresh (A2, 2026-07-14) ──────────
+
+class _Resp:
+    def __init__(self, status, data):
+        self.status = status
+        self._d = data
+    def read(self, n=-1):
+        return self._d if (n is None or n < 0) else self._d[:n]
+    def __enter__(self):
+        return self
+    def __exit__(self, *a):
+        return False
+
+
+def test_head_tail_download_concatenates_ranges(tmp_path, monkeypatch):
+    """Fetch a head slice + a tail slice via Range and concatenate them — the
+    geometry in the middle is never pulled."""
+    seen = []
+
+    def fake_urlopen(req, timeout=None):
+        rng = req.headers.get('Range', '')
+        seen.append(rng)
+        return _Resp(206, b'HEAD' + b'h' * 20) if rng.startswith('bytes=0-') \
+            else _Resp(206, b'TAIL' + b't' * 20)
+
+    monkeypatch.setattr(urllib.request, 'urlopen', fake_urlopen)
+    dest = tmp_path / 'g.gcode'
+    n = epfp.http_download_head_tail('http://x/g', dest, head_bytes=64, tail_bytes=64)
+    body = dest.read_bytes()
+    assert body.startswith(b'HEAD') and b'TAIL' in body
+    assert n == len(body)
+    assert any(r.startswith('bytes=0-') for r in seen)
+    assert any(r.startswith('bytes=-') for r in seen)
+
+
+def test_head_tail_download_distrusts_ignored_range(tmp_path, monkeypatch):
+    """If the server ignores Range (200), don't treat the body as a settings
+    tail — write head-only so the caller finds no footer and skips."""
+    monkeypatch.setattr(urllib.request, 'urlopen',
+                        lambda req, timeout=None: _Resp(200, b'X' * 30))
+    dest = tmp_path / 'g.gcode'
+    epfp.http_download_head_tail('http://x/g', dest, head_bytes=16, tail_bytes=16)
+    assert dest.stat().st_size == 16  # head-only, not both slices
+
+
+def test_refresh_from_printer_incremental_skip(tmp_path, monkeypatch):
+    """Skips prints already extracted, tail-fetches only the new ones."""
+    out = tmp_path / 'from-printer'
+    out.mkdir()
+    (out / (epfp.safe_basename('g1.gcode') + '_process.json')).write_text('{}')
+    monkeypatch.setattr(epfp, 'list_gcodes',
+                        lambda h, p, timeout=12.0: [{'path': 'g1.gcode'}, {'path': 'g2.gcode'}])
+    seen = {}
+
+    def fake_extract_one(host, port, name, output_dir, *, tail_bytes=None, **k):
+        seen['tail_bytes'] = tail_bytes
+        (output_dir / (epfp.safe_basename(name) + '_process.json')).write_text('{}')
+        return {'ok': True}
+
+    monkeypatch.setattr(epfp, 'extract_one', fake_extract_one)
+    summary = epfp.refresh_from_printer(host='h', port=1, output_dir=out, limit=5)
+    assert summary['skipped'] == 1          # g1 already had a profile
+    assert summary['extracted'] == ['g2']   # only g2 fetched
+    assert seen['tail_bytes']               # fetched tail-only, not the full file

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -84,6 +84,31 @@ def test_build_form_spec_refreshes_toolmap_before_render(monkeypatch):
     assert calls["n"] == 1, "refresh=False must not query the printer"
 
 
+def test_build_form_spec_marks_recommended_profile(monkeypatch):
+    """A1: the form passes the operator's last-used preset to the picker and
+    carries the recommended flag through, so the schema pre-selects it."""
+    import u1_form
+    seen = {}
+
+    def fake_list_profiles(nozzle=None, history_print_settings_id=None):
+        seen["history_id"] = history_print_settings_id
+        return [
+            {"value": "a", "label": "0.20 Standard @Snapmaker U1 (0.4 nozzle)"},
+            {"value": "b", "label": "0.16 Optimal @Snapmaker U1 (0.4 nozzle)",
+             "recommended": True},
+        ]
+
+    monkeypatch.setattr(kw, "list_profiles", fake_list_profiles)
+    monkeypatch.setattr(kw, "last_used_print_settings_id", lambda **k: "0.16 Optimal")
+    spec = kw._build_form_spec(_kit(1), "0.4", refresh=False)
+    assert seen["history_id"] == "0.16 Optimal", "must tell the picker the last-used preset"
+    rec = [p for p in spec["profiles"] if p.get("recommended")]
+    assert len(rec) == 1 and rec[0]["idx"] == 2, "recommended profile carried into the spec"
+    schema = u1_form.build_form_schema(spec)
+    pf = next(f for f in schema["fields"] if f["id"] == "profile")
+    assert pf["default"] == 2, "schema pre-selects the recommended profile end-to-end"
+
+
 # ---------- schema ----------
 
 def test_schema_quantity_field_rides_setup_group():
@@ -277,7 +302,7 @@ def _args(model, **kw_):
 @pytest.fixture
 def hermetic_commit(monkeypatch):
     """Stub the slicer/printer boundary; capture the paths handed to arrange."""
-    monkeypatch.setattr(kw, "list_profiles", lambda nozzle=None: [
+    monkeypatch.setattr(kw, "list_profiles", lambda nozzle=None, history_print_settings_id=None: [
         {"value": "0_20_standard", "label": "0.20 Standard @Snapmaker U1 (0.4 nozzle)"}])
     captured = {"calls": []}
 

--- a/tests/test_u1_form.py
+++ b/tests/test_u1_form.py
@@ -52,6 +52,35 @@ def test_order_independent():
     assert v["action"] == "start"
 
 
+# --------------------------------------------------------------------------- #
+# Profile pre-selection (A1, 2026-07-14): the form defaults to the picker's
+# recommended (last-used) profile instead of starting unselected, so the
+# operator isn't forced to re-pick their usual profile every run.
+# --------------------------------------------------------------------------- #
+
+def _spec_recommended(rec_idx):
+    s = _spec()
+    s["profiles"] = [
+        {"idx": 1, "label": "0.20 Standard @Snapmaker U1 (0.4 nozzle)", "recommended": rec_idx == 1},
+        {"idx": 2, "label": "0.16 Optimal @Snapmaker U1 (0.4 nozzle)", "recommended": rec_idx == 2},
+    ]
+    return s
+
+
+def test_profile_field_defaults_to_recommended():
+    schema = u1_form.build_form_schema(_spec_recommended(2))
+    pf = next(f for f in schema["fields"] if f["id"] == "profile")
+    assert pf["default"] == 2, "profile field must pre-select the recommended (last-used) profile"
+
+
+def test_profile_field_no_default_without_recommendation():
+    # Back-compat: no recommended flag -> no default (starts unselected, the
+    # pre-A1 behavior), so callers/tests that never mark one are unaffected.
+    schema = u1_form.build_form_schema(_spec())
+    pf = next(f for f in schema["fields"] if f["id"] == "profile")
+    assert "default" not in pf
+
+
 def test_forgiving_separators_and_case():
     r = u1_form.parse_answers("t0 ; pla ; PROFILE 1 ; NO-SUPPORTS", _spec(n_parts=0))
     assert r["ok"], r["errors"]

--- a/tests/test_u1_form_handoff.py
+++ b/tests/test_u1_form_handoff.py
@@ -85,7 +85,7 @@ def _args(model, **kw_):
 
 @pytest.fixture
 def hermetic_commit(monkeypatch):
-    monkeypatch.setattr(kw, "list_profiles", lambda nozzle=None: [
+    monkeypatch.setattr(kw, "list_profiles", lambda nozzle=None, history_print_settings_id=None: [
         {"value": "0_20_standard", "label": "0.20 Standard @Snapmaker U1 (0.4 nozzle)"}])
 
     def fake_arrange(paths, out_dir, **kwargs):

--- a/tests/test_u1_kit_workflow.py
+++ b/tests/test_u1_kit_workflow.py
@@ -70,7 +70,7 @@ def _args(model, **kw_):
 
 @pytest.fixture
 def fake_profiles(monkeypatch):
-    monkeypatch.setattr(kw, "list_profiles", lambda nozzle=None: [
+    monkeypatch.setattr(kw, "list_profiles", lambda nozzle=None, history_print_settings_id=None: [
         {"value": "0_20_standard", "label": "0.20 Standard @Snapmaker U1 (0.4 nozzle)"},
         {"value": "0_16_optimal", "label": "0.16 Optimal @Snapmaker U1 (0.4 nozzle)"},
     ])
@@ -127,7 +127,7 @@ def test_turn1_form_profiles_not_clobbered_by_reinvocation(tmp_path, monkeypatch
     # survive a second no-answer invocation even if list_profiles has
     # re-sorted between them. Without the guard, `profile 1` on a later
     # --form-answers call resolves against a list the operator never saw.
-    monkeypatch.setattr(kw, "list_profiles", lambda nozzle=None: [
+    monkeypatch.setattr(kw, "list_profiles", lambda nozzle=None, history_print_settings_id=None: [
         {"value": "A", "label": "A-label"},
         {"value": "B", "label": "B-label"},
     ])
@@ -138,7 +138,7 @@ def test_turn1_form_profiles_not_clobbered_by_reinvocation(tmp_path, monkeypatch
     persisted_1 = [p["value"] for p in u1_request.read_request(rid)["form_profiles"]]
     assert persisted_1 == ["A", "B"]
     # Flip the order — simulate history-driven re-sort
-    monkeypatch.setattr(kw, "list_profiles", lambda nozzle=None: [
+    monkeypatch.setattr(kw, "list_profiles", lambda nozzle=None, history_print_settings_id=None: [
         {"value": "B", "label": "B-label"},
         {"value": "A", "label": "A-label"},
     ])
@@ -254,7 +254,7 @@ def test_profile_index_stable_via_persisted_list(tmp_path, fake_profiles, fake_s
     r1 = kw.run_kit_workflow(_args(zp))  # persists form_profiles = [standard, optimal]
     rid = r1["request_id"]
     # Now flip list_profiles order to simulate a history-driven re-sort.
-    monkeypatch.setattr(kw, "list_profiles", lambda nozzle=None: [
+    monkeypatch.setattr(kw, "list_profiles", lambda nozzle=None, history_print_settings_id=None: [
         {"value": "0_16_optimal", "label": "0.16 Optimal @Snapmaker U1 (0.4 nozzle)"},
         {"value": "0_20_standard", "label": "0.20 Standard @Snapmaker U1 (0.4 nozzle)"},
     ])
@@ -698,7 +698,7 @@ def test_resolve_operator_env_fallback_and_unknown(monkeypatch):
 def test_kit_setup_required_when_no_profiles(tmp_path, monkeypatch):
     """No profiles → the unified flow emits setup_required(no_profiles) and exits
     clean, not a crash. Migrated from the retired single-flow empty_picker test."""
-    monkeypatch.setattr(kw, "list_profiles", lambda nozzle=None: [])
+    monkeypatch.setattr(kw, "list_profiles", lambda nozzle=None, history_print_settings_id=None: [])
     res = kw.run_kit_workflow(_args(_kit_zip(tmp_path, 1), interaction_mode="form"))
     assert res["phase"] == "setup_required"
 

--- a/tests/test_u1_profile_picker.py
+++ b/tests/test_u1_profile_picker.py
@@ -279,3 +279,56 @@ def test_no_nozzle_arg_keeps_everything(tmp_path):
     _write_process_json(tmp_path / '0.06 High Quality @Snapmaker U1 (0.2 nozzle).json')
     opts = list_profiles(tmp_path)
     assert len(opts) == 2
+
+
+# --------------------------------------------------------------------------- #
+# from-printer surfacing (A2, 2026-07-14): profiles derived from recent prints
+# read by their real name (not the gcode filename), and reprints collapse.
+# --------------------------------------------------------------------------- #
+
+def _write_from_printer(path: Path, internal_name: str) -> None:
+    path.write_text(json.dumps({"type": "process", "name": internal_name}))
+
+
+def test_from_printer_profile_labeled_by_internal_name(tmp_path):
+    fp = tmp_path / 'from-printer'
+    fp.mkdir()
+    _write_from_printer(fp / 'Phillips_Hue_plate1_20260714_process.json',
+                        'Community 0.20 Strength Gyroid @Snapmaker U1 Textured PEI')
+    opts = list_profiles(sources=(('from-printer', fp),))
+    assert len(opts) == 1
+    # reads as the profile's real name, decorations stripped — NOT the gcode file
+    assert opts[0]['label'] == '0.20 Strength Gyroid'
+
+
+def test_from_printer_reprints_collapse_newest_kept(tmp_path):
+    import os
+    fp = tmp_path / 'from-printer'
+    fp.mkdir()
+    old = fp / 'hue_run1_process.json'
+    new = fp / 'hue_run2_process.json'
+    _write_from_printer(old, '0.20 Strength Gyroid')
+    _write_from_printer(new, '0.20 Strength Gyroid')
+    os.utime(old, (1000, 1000))
+    os.utime(new, (2000, 2000))
+    opts = list_profiles(sources=(('from-printer', fp),))
+    assert len(opts) == 1, [o['value'] for o in opts]   # two reprints -> one entry
+    assert 'hue_run2' in opts[0]['value']                # the newer file survives
+
+
+def test_same_name_across_sources_collapses_highest_priority_wins(tmp_path):
+    # A captured print and a hand-saved user profile with the SAME name must
+    # show once (not "0.20 Strength Gyroid" twice), from-printer kept.
+    fp = tmp_path / 'from-printer'
+    fp.mkdir()
+    user = tmp_path / 'user'
+    user.mkdir()
+    _write_from_printer(fp / 'hue_print_process.json',
+                        'Community 0.20 Strength Gyroid @Snapmaker U1 Textured PEI')
+    (user / '0.20 Strength Gyroid.json').write_text(
+        json.dumps({"type": "process", "enable_support": "0"}))
+    opts = list_profiles(sources=(('from-printer', fp), ('user', user)))
+    labels = [o['label'] for o in opts]
+    assert labels.count('0.20 Strength Gyroid') == 1, labels
+    kept = next(o for o in opts if o['label'] == '0.20 Strength Gyroid')
+    assert kept['source'] == 'from-printer'

--- a/tests/test_u1_review_doc.py
+++ b/tests/test_u1_review_doc.py
@@ -305,7 +305,7 @@ def test_kit_commit_emits_review_doc_and_never_blocks(tmp_path, capsys, monkeypa
         for i in range(2):
             z.write(_cube(tmp_path / f"p{i}.stl", 20 + i), f"p{i}.stl")
 
-    monkeypatch.setattr(kw, "list_profiles", lambda nozzle=None: [
+    monkeypatch.setattr(kw, "list_profiles", lambda nozzle=None, history_print_settings_id=None: [
         {"value": "0_20_standard", "label": "0.20 Standard @Snapmaker U1 (0.4 nozzle)"}])
 
     def fake_arrange(paths, out_dir, **kwargs):

--- a/tools/extract_profiles_from_printer.py
+++ b/tools/extract_profiles_from_printer.py
@@ -121,6 +121,39 @@ def http_download(url: str, dest: Path, timeout: float = 120.0) -> int:
     return bytes_written
 
 
+def http_download_head_tail(url: str, dest: Path, *, head_bytes: int = 262144,
+                            tail_bytes: int = 1048576, timeout: float = 30.0) -> int:
+    """Fetch only the HEAD + TAIL of a G-code via HTTP Range requests and write
+    them (concatenated) to dest — transferring ~1 MB instead of a whole print.
+
+    The geometry in the middle is never downloaded. The intended tool is a
+    T-command in the first lines (``_detect_tool_index`` scans the first 300);
+    the slicer settings are the trailing comment block
+    (``parse_gcode_metadata`` seeks the last 512 KB). So a head slice covers the
+    former and a tail slice the latter. Reads are BOUNDED, so a server that
+    ignores Range can't make us pull the whole file — we then get a head-only
+    chunk with no settings footer, which the caller skips. Returns bytes written.
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    def _range(hdr: str, cap: int) -> tuple[int, bytes]:
+        req = urllib.request.Request(url, headers={"Range": hdr})
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as r:
+                return getattr(r, "status", 200), r.read(cap)
+        except Exception:
+            return 0, b""
+
+    hs, head = _range(f"bytes=0-{head_bytes - 1}", head_bytes)
+    ts, tail = _range(f"bytes=-{tail_bytes}", tail_bytes)
+    # Only trust the tail slice when the server honored the suffix range (206);
+    # otherwise `tail` is just the file start again and carries no settings
+    # footer, so write head-only and let the caller find no metadata + skip.
+    body = ((head if hs == 206 else b"") + tail) if ts == 206 else head
+    dest.write_bytes(body)
+    return len(body)
+
+
 def list_gcodes(host: str, port: int, timeout: float = 12.0) -> list[dict[str, Any]]:
     """Return Moonraker's listing of files under root=gcodes, newest first.
 
@@ -152,16 +185,27 @@ def extract_one(
     brand_label: str | None = None,
     keep_gcode: bool = False,
     download_dir: Path | None = None,
+    head_bytes: int = 262144,
+    tail_bytes: int | None = None,
 ) -> dict[str, Any]:
     """Download one G-code from the printer + extract its process + filament
-    profiles into output_dir. Returns a summary dict for reporting."""
+    profiles into output_dir. Returns a summary dict for reporting.
+
+    When ``tail_bytes`` is set, only the G-code's head + tail are fetched via
+    Range requests (settings live in the trailing comment block; the tool in the
+    first lines), so a 200 MB print costs a ~1 MB transfer instead of the whole
+    file. Left None (the CLI default) downloads the full file, unchanged."""
     base = f"http://{host}:{port}"
     download_dir = download_dir or output_dir / ".downloaded"
     download_dir.mkdir(parents=True, exist_ok=True)
     local = download_dir / Path(file_path).name
 
     url = f"{base}/server/files/gcodes/{urllib.parse.quote(file_path)}"
-    written = http_download(url, local)
+    if tail_bytes:
+        written = http_download_head_tail(url, local, head_bytes=head_bytes,
+                                          tail_bytes=tail_bytes)
+    else:
+        written = http_download(url, local)
 
     meta = epfg.parse_gcode_metadata(local)
     if not meta:
@@ -206,6 +250,52 @@ def extract_one(
         "filament_type": filament_meta.get("filament_type"),  # post-slice
         "layer_height": meta.get("layer_height"),
     }
+
+
+def already_extracted(output_dir: Path, file_path: str) -> bool:
+    """True if this G-code's process profile is already in output_dir — the
+    incremental-skip key so a spool of reprints doesn't re-fetch every time."""
+    return (output_dir / f"{safe_basename(file_path)}_process.json").exists()
+
+
+def refresh_from_printer(host: str | None = None, port: int | None = None,
+                         output_dir: Path | None = None, *, limit: int = 5,
+                         head_bytes: int = 262144, tail_bytes: int = 1048576,
+                         timeout: float = 30.0, vendor: str | None = None) -> dict:
+    """Incrementally populate ``profiles/from-printer/`` from the printer's most
+    recent prints, fetching ONLY each G-code's head+tail (settings), never the
+    geometry. Skips prints already extracted, so it is cheap enough to run inline
+    at form-build. Fully GUARDED: never raises; returns a summary dict
+    ``{extracted, skipped, errors}`` so a printer that's off/unreachable simply
+    leaves the existing profiles in place."""
+    summary: dict[str, Any] = {"extracted": [], "skipped": 0, "errors": []}
+    try:
+        if host is None or port is None:
+            from u1_config import get_u1_host, get_u1_port
+            host = host or get_u1_host()
+            port = port if port is not None else get_u1_port()
+        output_dir = output_dir or DEFAULT_OUTPUT_DIR
+        gcodes = list_gcodes(host, int(port), timeout=timeout)
+    except Exception as exc:
+        summary["errors"].append(f"list: {exc}")
+        return summary
+    for g in gcodes[:max(0, int(limit))]:
+        name = g.get("path") or g.get("filename") or g.get("name")
+        if not name:
+            continue
+        try:
+            if already_extracted(output_dir, name):
+                summary["skipped"] += 1
+                continue
+            res = extract_one(host, int(port), name, output_dir, vendor=vendor,
+                              head_bytes=head_bytes, tail_bytes=tail_bytes)
+            if res.get("ok"):
+                summary["extracted"].append(safe_basename(name))
+            else:
+                summary["errors"].append(f"{name}: {res.get('error')}")
+        except Exception as exc:
+            summary["errors"].append(f"{name}: {exc}")
+    return summary
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
## Profiles from your recent prints, and it defaults to your last one

Two profile improvements that make a normal print quicker to start.

**Profiles from your recent prints.** The picker now offers profiles pulled from what you have actually printed, not just the bundled Snapmaker presets. Send a kit and the toolkit reads the settings from your recent prints on the printer and offers them, named the way your slicer named them. It fetches only the small settings block from each print, never the whole G-code, so a large print is about a 1 MB transfer. Reprints collapse to one entry, and a captured print that matches a profile you already have shows once.

**Defaults to your last-used.** The form opens pre-selected on the profile you last printed with, instead of blank, so a normal print is one tap shorter. You can still change it.

### How it works
- `refresh_from_printer` scrubs recent G-codes into `profiles/from-printer/` at form-build via HTTP Range (head+tail only), incremental, guarded, never under tests.
- The picker labels from-printer profiles by their real name and dedups reprints + cross-source name matches.
- The form-path `list_profiles` calls pass the last-used preset from `print_history`; `build_form_schema` sets the profile field default.

### Verification
Full suite: 1016 passed, 8 skipped. Self-tested end-to-end on real hardware: the `u1_kit` flow scrubbed recent prints, pre-selected the last-used, and sliced a real gcode with the from-printer profile (reached the bed-clear prompt, nothing printed).
