### PR TITLE
v2.5.1: print-start gate uses filament_exist, not the idle motion sensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2.5.1] — 2026-07-14
+
+### Fixed
+
+- **The print-start safety check no longer refuses a loaded tool that's sitting
+  idle.** The check that confirms filament is loaded before a print starts was
+  reading the tool's filament-motion sensor, which only registers while filament
+  is actively moving. At the moment you approve a print every tool is idle, so a
+  genuinely loaded tool could read as "not loaded" and the start was refused. It
+  now reads the printer's own per-tool loaded/not-loaded status instead. A tool
+  that is actually empty still blocks the start, unchanged.
+
+---
+
 ## [2.5.0] — 2026-07-14
 
 ### Added

--- a/scripts/u1_toolmap.py
+++ b/scripts/u1_toolmap.py
@@ -284,10 +284,19 @@ def summarize(raw: dict[str, Any], material_map: dict[str, Any], requested_mater
             printer_material = (tool.get("printer_reported", {}).get("material") or "unknown").upper()
             declared_material = (tool.get("declared", {}).get("material") or "unknown").upper()
             detected_material = printer_material if printer_material not in {"", "UNKNOWN", "NONE"} else declared_material
-            sensors = tool.get("filament_sensors", {})
             exists = tool.get("printer_reported", {}).get("exists")
-            if exists is False or sensors.get("motion_detected") is False or sensors.get("feed_detected") is False:
-                gates.append(f"requested material {requested_norm} blocked: {check_tool} filament presence sensor says not loaded")
+            # "Loaded" on the U1 is the per-tool `filament_exist` flag (verified
+            # against the machine 2026-07-15: filament_exist=[T,T,T,T] on loaded
+            # tools, matching the visible colour/material). The
+            # filament_motion_sensor (motion_detected / feed_detected) only reads
+            # True while filament is actively MOVING through a head; at rest —
+            # which is EVERY tool at pre-start, before the head engages the
+            # colour — it reads False. Gating on it blocked every loaded-but-idle
+            # tool (live 2026-07-15: a real print refused with exists=True,
+            # motion=feed=False). So gate on presence (exists), not motion; the
+            # motion sensor is the printer's own DURING-print runout mechanism.
+            if exists is False:
+                gates.append(f"requested material {requested_norm} blocked: {check_tool} filament not loaded (filament_exist is false)")
             elif detected_material in {"", "UNKNOWN", "NONE"}:
                 gates.append(f"requested material {requested_norm} cannot be verified: {check_tool} material is unknown")
             elif detected_material != requested_norm:

--- a/tests/test_u1_toolmap.py
+++ b/tests/test_u1_toolmap.py
@@ -87,6 +87,31 @@ def test_no_request_means_no_gate():
     assert not blocking
 
 
+def test_idle_loaded_tool_not_blocked_by_motion_sensor():
+    """U1 (verified 2026-07-15): a LOADED tool (filament_exist True) whose motion
+    sensor reads False because it's idle/not feeding must NOT be gated. The
+    motion sensor only fires while filament is actively moving; at pre-start
+    every tool is idle, so gating on it refused every real print."""
+    raw = _fake_printer_raw(e1_material="PETG")
+    st = raw["status"]
+    # extruder1 is channel 1 (EXTRUDER_CHANNEL): load ch1 + set its material.
+    st["print_task_config"]["filament_exist"] = [False, True, False, False]
+    st["print_task_config"]["filament_type"] = ["", "PETG", "", ""]
+    st["filament_motion_sensor e1_filament"] = {"filament_detected": False, "enabled": True}
+    out = u1_toolmap.summarize(raw, _material_map(material="PETG"),
+                               requested_material="PETG", intended_tool="extruder1")
+    assert not [g for g in out.get("gates", []) if "not loaded" in g], out.get("gates")
+
+
+def test_empty_tool_still_blocked_by_filament_exist():
+    """Safety intact: a genuinely empty tool (filament_exist False) MUST block."""
+    raw = _fake_printer_raw(e1_material="PETG")
+    raw["status"]["print_task_config"]["filament_exist"] = [False, False, False, False]
+    out = u1_toolmap.summarize(raw, _material_map(material="PETG"),
+                               requested_material="PETG", intended_tool="extruder1")
+    assert [g for g in out.get("gates", []) if "not loaded" in g], out.get("gates")
+
+
 def test_case_insensitive_material_match():
     """petg vs PETG should still match — operator typing convenience."""
     raw = _fake_printer_raw(e1_material="petg")


### PR DESCRIPTION
## Print-start gate no longer refuses a loaded-but-idle tool

The preflight check that confirms filament is loaded before a print starts was reading the tool's motion sensor (`filament_motion_sensor.filament_detected`). That sensor only reads true while filament is actively moving through a feeding head. At the moment you approve a print every tool is idle, so a genuinely loaded tool (`filament_exist=True`, visible colour/material) read as "not loaded" and the start was refused.

**Verified against the live U1:** a real PLA print on T3 refused with `exists=True, motion_detected=False, feed_detected=True`. With the fix the same case passes; a genuinely empty tool (`filament_exist=False`) still blocks.

### Change
- `u1_toolmap.summarize` gates on `filament_exist` (the printer's per-tool loaded/not-loaded flag) instead of the motion/feed sensors. The motion sensor is the printer's own runout mechanism *during* a print, not a pre-start loaded check.
- Regression tests: idle loaded tool (exists=True, motion/feed False) must not block; empty tool (exists=False) must block.

Latent until now because prior drills always ended at grace-cancel, never reaching a real (non-cancelled) start where this preflight fires.

### Verification
Full suite: 1018 passed, 8 skipped. Reproduced the exact live failing case (PLA/T3) and confirmed the gate now allows it while still blocking an empty tool.
