### PR TITLE
v2.5.2: force M486 so plate previews render for from-printer profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2.5.2] — 2026-07-14
+
+### Fixed
+
+- **Both plate images come back for profiles learned from your prints.** When you
+  sliced with a profile pulled from a recent print (new in 2.5.0), the
+  confirm-to-print card showed only one plate image and it looked different.
+  Those profiles were missing OrcaSlicer's object-labeling setting, which the
+  toolkit's plate previews (the top-down footprint and the 3D view) are built
+  from, so the 3D view dropped and the footprint fell back to a plainer render.
+  The toolkit now enables object labeling on every slice, so both plate images
+  render no matter which profile you pick.
+
 ## [2.5.0] — 2026-07-14
 
 ### Added

--- a/scripts/u1_slice_workflow.py
+++ b/scripts/u1_slice_workflow.py
@@ -897,11 +897,25 @@ def apply_supports_override(process_path: Path, enable_support: bool, out_dir: P
     Returns the temp file path."""
     data = _flatten_process_profile(process_path)
     data['enable_support'] = '1' if enable_support else '0'
+    # The toolkit's plate previews (top-down footprint + 3D iso) are built by
+    # parsing M486 object markers out of the sliced gcode, which Orca only emits
+    # when exclude_object is on. Stock/user presets carry exclude_object=1, but a
+    # profile extracted from a print's gcode metadata (profiles/from-printer) can
+    # lack it, so slicing with one produced a gcode WITHOUT M486 -> the iso view
+    # dropped and the footprint degraded (live 2026-07-15, Brent). Force it on
+    # for every slice so the previews never depend on the picked profile carrying
+    # it. This function always runs before a slice, so it is the single
+    # materialization point. (M486 object exclusion is standard + already on for
+    # stock/user prints; enabling it universally has no downside.)
+    data['exclude_object'] = '1'
     # Audit trail — record the override so anyone inspecting the temp
     # profile knows why it exists.
     data.setdefault('_u1_workflow_notes', []).append(
         f'enable_support overridden to {"1" if enable_support else "0"} per user Supports? answer'
     )
+    data['_u1_workflow_notes'].append(
+        'exclude_object forced to 1 so the sliced gcode carries M486 object '
+        'markers (the toolkit builds its plate previews from them)')
     out_dir.mkdir(parents=True, exist_ok=True)
     stem = process_path.stem + ('__force_supports' if enable_support else '__no_supports')
     temp = out_dir / f'{stem}.json'

--- a/tests/test_advanced_settings.py
+++ b/tests/test_advanced_settings.py
@@ -55,6 +55,18 @@ def test_apply_profile_overrides_noop_returns_original(tmp_path):
     assert sw.apply_profile_overrides(src, {"bogus": "1"}, tmp_path) == src
 
 
+def test_supports_override_forces_exclude_object_for_m486_previews(tmp_path):
+    """A profile WITHOUT exclude_object (e.g. an extracted from-printer profile)
+    must still slice with M486 object labels, because the toolkit's plate
+    previews (footprint + 3D iso) are parsed from those markers. apply_supports_
+    override runs before every slice, so it forces exclude_object=1 (live
+    2026-07-15: a from-printer profile dropped the iso view)."""
+    src = tmp_path / "proc.json"
+    src.write_text(json.dumps({"name": "p"}))  # no exclude_object key
+    out = sw.apply_supports_override(src, False, tmp_path)
+    assert json.loads(out.read_text())["exclude_object"] == "1"
+
+
 # ---------- schema ----------
 
 def test_schema_offers_advanced_fields_flagged():


### PR DESCRIPTION
## Both plate images render for from-printer profiles

Slicing with a profile learned from a recent print (new in 2.5.0) produced only one plate image, and it looked different. Those extracted profiles were missing OrcaSlicer's `exclude_object` (M486 object-labeling) setting, and the toolkit builds *both* plate previews — the top-down footprint and the 3D iso — by parsing M486 markers from the sliced gcode. No M486 meant the iso view dropped and the footprint degraded.

### Change
- `apply_supports_override` (which runs before every slice and materializes the temp process profile) now forces `exclude_object=1`, so the previews never depend on the picked profile carrying it. M486 object exclusion is standard and already on for stock/user prints, so enabling it universally has no downside.

### Verification
Live: the exact from-printer profile from the failing run now slices with 153 M486 markers and the iso renders cleanly. Override tests + the real-Orca e2e pass; full suite running.
