### PR TITLE
Redesign Advanced options: category menu, current-value headers, compact layout

### DIFF
--- a/adapters/hermes/plugin/telegram_patch.py
+++ b/adapters/hermes/plugin/telegram_patch.py
@@ -27,7 +27,7 @@ invisible to PTB. Live v2.2 finding (2026-07-02): with the swap approach
 every button press routed to the native handler, toggles never rendered,
 and the form sat untouched until its 600s timeout. The form callback
 vocabulary is exclusively single-char prefixes (``t: s: p: a: z: n: e:
-S X``) while Hermes' own callbacks are all multi-char + colon (``cl:``,
+g: S X``) while Hermes' own callbacks are all multi-char + colon (``cl:``,
 ``ea:``, ``mp:``…), so the pattern can never shadow a native callback.
 
 File handoff: when the schema carries ``submit: {mode: "file", form_id}``,
@@ -45,7 +45,10 @@ logger = logging.getLogger(__name__)
 # The renderer's complete callback vocabulary — and nothing else. Anchored so
 # a native Hermes callback (multi-char prefix + colon) can never match.
 # S:<f>:<o> is a submit-verb (sets the Action option, then submits).
-FORM_CB_PATTERN = r"^(?:[tsp]:\d+:\d+|S:\d+:\d+|[azne]:\d+|[SX])$"
+# g:<sub> is the Advanced-options menu (g:m menu, g:d done, g:r reset,
+# g:c:<category> open a category) — a SINGLE-char prefix, so it stays inside
+# the form vocabulary and never shadows a native multi-char callback.
+FORM_CB_PATTERN = r"^(?:[tsp]:\d+:\d+|S:\d+:\d+|[azne]:\d+|g:(?:[mdr]|c:[a-z_]+)|[SX])$"
 
 # Grace-window cancel button on the countdown DM (u1c:<request_id>). Handled
 # HERE — the gateway adapter layer — because a typed CANCEL that lands while

--- a/adapters/telegram/u1_form_telegram.py
+++ b/adapters/telegram/u1_form_telegram.py
@@ -323,6 +323,33 @@ def _field_control_rows(form: dict[str, Any], field: dict[str, Any],
     is_multi = field["type"] == "multi_select"
     page_offset = page * PAGE_SIZE
     sel = form["selections"][field["id"]]
+    # Advanced controls (the category sub-pages) get a per-setting BLOCK layout,
+    # not one button per row: the current/keep value is a full-width headline,
+    # its alternatives pack two-up beneath. Keeps each setting a scannable unit
+    # instead of a tall column of every option (live 2026-07-15: the flat stack
+    # read as "a fat chunk of info"). Advanced fields never paginate (<=7 opts).
+    if field.get("advanced"):
+        pending: list[dict[str, str]] = []
+        for oi, opt in enumerate(field["options"]):
+            oid = _opt_id(opt)
+            lbl = _opt_label(opt)
+            if resolved_default and oid == "default":
+                lbl = lbl.replace("profile default", f"keep profile ({resolved_default})")
+            btn = {"text": f"{'● ' if sel == oi else '○ '}{lbl}",
+                   "callback_data": f"s:{fi}:{oi}"}
+            if oid == "default":                       # headline: its own row
+                if pending:
+                    rows.append(pending)
+                    pending = []
+                rows.append([btn])
+            else:                                      # alternatives: two-up
+                pending.append(btn)
+                if len(pending) == 2:
+                    rows.append(pending)
+                    pending = []
+        if pending:
+            rows.append(pending)
+        return rows
     compact = field.get("compact") and not is_multi
     _pending: list[dict[str, str]] = []
     for local_oi, opt in enumerate(slice_):

--- a/adapters/telegram/u1_form_telegram.py
+++ b/adapters/telegram/u1_form_telegram.py
@@ -349,10 +349,10 @@ def _field_control_rows(form: dict[str, Any], field: dict[str, Any],
     if paginated and total_pages > 1:
         nav: list[dict[str, str]] = []
         if page > 0:
-            nav.append({"text": "‹ Prev", "callback_data": f"p:{fi}:{page - 1}"})
+            nav.append({"text": "‹ Prev page", "callback_data": f"p:{fi}:{page - 1}"})
         nav.append({"text": f"{page + 1}/{total_pages}", "callback_data": f"p:{fi}:{page}"})
         if page + 1 < total_pages:
-            nav.append({"text": "Next ›", "callback_data": f"p:{fi}:{page + 1}"})
+            nav.append({"text": "More ›", "callback_data": f"p:{fi}:{page + 1}"})
         rows.append(nav)
     if is_multi:
         multi_row = [
@@ -376,12 +376,22 @@ def _multi_hint(field: dict[str, Any], sel) -> str:
 
 def _render_field(form: dict[str, Any], field: dict[str, Any]) -> dict[str, Any]:
     rows = _field_control_rows(form, field)
-    rows.append([{"text": "✖ Cancel", "callback_data": "X"}])
     label = _esc(field.get("label", field["id"]))
     hint = tip = ""
     if field["type"] == "multi_select":
         hint = _multi_hint(field, form["selections"][field["id"]])
         tip = "\n<i>Tap options to toggle ✔, then Next ➜</i>"
+    # A single-select advances when you TAP an option — but when one is already
+    # selected (a pre-selected default like the last-used profile) the operator
+    # looks for a way forward and the only forward-looking button is pagination.
+    # Give an explicit Continue so "keep this one, move on" is a real button
+    # (live 2026-07-15: the paginated profile screen's "Next" paged instead).
+    elif field.get("type") == "single_select" and not field.get("group") \
+            and form["selections"].get(field["id"]) is not None:
+        tip = "\n<i>Tap another to change, or Continue ➜</i>"
+        rows.append([{"text": "✅ Continue ➜",
+                      "callback_data": f"n:{_field_index(form, field['id'])}"}])
+    rows.append([{"text": "✖ Cancel", "callback_data": "X"}])
     text = f"<b>{label}</b>{hint}{tip}" + _step_suffix(form, field["id"])
     return {"text": text, "keyboard": rows}
 
@@ -448,9 +458,9 @@ def _render_review(form: dict[str, Any]) -> dict[str, Any]:
         if changed:
             lines.append("\u2022 <b>Advanced</b>: " + _esc(", ".join(changed)))
         rows.append([{
-            "text": ("\u2699 Print tweaks"
+            "text": ("\u2699 Advanced options"
                      + (f" ({len(changed)} changed)" if changed else "")),
-            "callback_data": "am",
+            "callback_data": "g:m",
         }])
 
     # Action becomes the submit verbs: each option submits with that action.
@@ -479,18 +489,18 @@ def _render_adv_menu(form: dict[str, Any]) -> dict[str, Any]:
     """Level 1 of the tweak sub-pages: the category menu, reached from Review's
     ⚙ button. Lists only categories that have applicable fields; each shows how
     many of its controls are set away from the profile default."""
-    lines = ["<b>⚙ Print tweaks</b>",
+    lines = ["<b>⚙ Advanced options</b>",
              "All optional. Anything you leave alone keeps the profile's value.",
              ""]
     rows: list[list[dict[str, str]]] = []
     for key, label, fields in _adv_categories(form):
         n = _adv_changed_count(form, fields)
         text = _esc(label) + (f"  · {n} changed" if n else "")
-        rows.append([{"text": text, "callback_data": f"cat:{key}"}])
+        rows.append([{"text": text, "callback_data": f"g:c:{key}"}])
     if _adv_changed_count(form, _advanced_fields(form)):
-        rows.append([{"text": "↩ Reset all to profile", "callback_data": "ar"}])
+        rows.append([{"text": "↩ Reset all to profile", "callback_data": "g:r"}])
     rows.append([
-        {"text": "✅ Done", "callback_data": "ad"},
+        {"text": "✅ Done", "callback_data": "g:d"},
         {"text": "✖ Cancel", "callback_data": "X"},
     ])
     return {"text": "\n".join(lines), "keyboard": rows}
@@ -505,14 +515,14 @@ def _render_adv_category(form: dict[str, Any], catkey: str) -> dict[str, Any]:
         form["current"] = ADV_MENU
         return _render_adv_menu(form)
     _key, label, fields = entry
-    lines = [f"<b>{_esc(label)}</b>", "Tap to change, then Back to tweaks."]
+    lines = [f"<b>{_esc(label)}</b>", "Tap to change, then Back to options."]
     resolved = _resolved_for_selected_profile(form)
     rows: list[list[dict[str, str]]] = []
     for field in fields:
         rows.extend(_field_control_rows(form, field,
                                         resolved_default=resolved.get(field["id"])))
     rows.append([
-        {"text": "↩ Back to tweaks", "callback_data": "am"},
+        {"text": "↩ Back to options", "callback_data": "g:m"},
         {"text": "✖ Cancel", "callback_data": "X"},
     ])
     return {"text": "\n".join(lines), "keyboard": rows}
@@ -584,28 +594,32 @@ def _apply_callback_inner(form: dict[str, Any], data: str) -> dict[str, Any]:
                     "warning": f"Please answer: {_esc(', '.join(missing))}"}
         return {"kind": "submit", "answer": answer_json(form)}
 
-    if kind == "am":              # open / return to the tweak category menu
-        form.pop("_edit_return", None)
-        form["current"] = ADV_MENU
-        return {"kind": "rerender"}
-
-    if kind == "ad":              # Done with tweaks → back to Review
-        form["current"] = REVIEW_FIELD
-        return {"kind": "rerender"}
-
-    if kind == "ar":              # Reset every advanced control to profile default
-        for f in _advanced_fields(form):
-            di = next((i for i, o in enumerate(f["options"])
-                       if _opt_id(o) == "default"), None)
-            if di is not None:
-                form["selections"][f["id"]] = di
-        return {"kind": "rerender"}
-
-    if kind == "cat":             # open a category sub-page
-        catkey = parts[1]
-        bucket = next((fs for k, _l, fs in _adv_categories(form) if k == catkey), None)
-        form["current"] = bucket[0]["id"] if bucket else ADV_MENU
-        return {"kind": "rerender"}
+    if kind == "g":               # Advanced-options menu navigation (g:<sub>)
+        # Namespaced under a single-char prefix so it stays inside the form's
+        # callback vocabulary and never shadows a native (multi-char + colon)
+        # Hermes callback — the gateway routes only FORM_CB_PATTERN.
+        sub = parts[1] if len(parts) > 1 else ""
+        if sub == "m":            # open / return to the category menu
+            form.pop("_edit_return", None)
+            form["current"] = ADV_MENU
+            return {"kind": "rerender"}
+        if sub == "d":            # Done → back to Review
+            form["current"] = REVIEW_FIELD
+            return {"kind": "rerender"}
+        if sub == "r":            # Reset every advanced control to profile default
+            for f in _advanced_fields(form):
+                di = next((i for i, o in enumerate(f["options"])
+                           if _opt_id(o) == "default"), None)
+                if di is not None:
+                    form["selections"][f["id"]] = di
+            return {"kind": "rerender"}
+        if sub == "c":            # open a category sub-page (g:c:<catkey>)
+            catkey = parts[2] if len(parts) > 2 else ""
+            bucket = next((fs for k, _l, fs in _adv_categories(form) if k == catkey), None)
+            form["current"] = bucket[0]["id"] if bucket else ADV_MENU
+            return {"kind": "rerender"}
+        return {"kind": "rerender",
+                "warning": f"Stale or invalid button ({_esc(data)})."}
 
     fi = int(parts[1])
     field = fields[fi]

--- a/adapters/telegram/u1_form_telegram.py
+++ b/adapters/telegram/u1_form_telegram.py
@@ -495,7 +495,9 @@ def _render_adv_menu(form: dict[str, Any]) -> dict[str, Any]:
     rows: list[list[dict[str, str]]] = []
     for key, label, fields in _adv_categories(form):
         n = _adv_changed_count(form, fields)
-        text = _esc(label) + (f"  · {n} changed" if n else "")
+        # Button text is NOT HTML-parsed — use the raw label so a "&" in a
+        # category name ("Strength & shells") shows as "&", not "&amp;".
+        text = label + (f"  · {n} changed" if n else "")
         rows.append([{"text": text, "callback_data": f"g:c:{key}"}])
     if _adv_changed_count(form, _advanced_fields(form)):
         rows.append([{"text": "↩ Reset all to profile", "callback_data": "g:r"}])

--- a/adapters/telegram/u1_form_telegram.py
+++ b/adapters/telegram/u1_form_telegram.py
@@ -329,26 +329,26 @@ def _field_control_rows(form: dict[str, Any], field: dict[str, Any],
     # instead of a tall column of every option (live 2026-07-15: the flat stack
     # read as "a fat chunk of info"). Advanced fields never paginate (<=7 opts).
     if field.get("advanced"):
-        pending: list[dict[str, str]] = []
+        # A full-width HEADER (the setting name + its current value; tap = keep
+        # the profile default) followed by the alternatives as BARE values three-
+        # up. The header carries the setting name so the option buttons don't
+        # repeat it (live 2026-07-15: "Infill 10% / Infill 15% / ..." doubled the
+        # text and truncated wider labels at two-up). The default option is first
+        # in every advanced field, so the header row lands before the values.
+        alts: list[dict[str, str]] = []
         for oi, opt in enumerate(field["options"]):
-            oid = _opt_id(opt)
-            lbl = _opt_label(opt)
-            if resolved_default and oid == "default":
-                lbl = lbl.replace("profile default", f"keep profile ({resolved_default})")
-            btn = {"text": f"{'● ' if sel == oi else '○ '}{lbl}",
-                   "callback_data": f"s:{fi}:{oi}"}
-            if oid == "default":                       # headline: its own row
-                if pending:
-                    rows.append(pending)
-                    pending = []
-                rows.append([btn])
-            else:                                      # alternatives: two-up
-                pending.append(btn)
-                if len(pending) == 2:
-                    rows.append(pending)
-                    pending = []
-        if pending:
-            rows.append(pending)
+            mark = "● " if sel == oi else "○ "
+            if _opt_id(opt) == "default":
+                head = _opt_label(opt)
+                if resolved_default:
+                    head = head.replace("profile default",
+                                        f"keep profile ({resolved_default})")
+                rows.append([{"text": f"{mark}{head}", "callback_data": f"s:{fi}:{oi}"}])
+            else:
+                short = opt.get("short") or _opt_label(opt)
+                alts.append({"text": f"{mark}{short}", "callback_data": f"s:{fi}:{oi}"})
+        for i in range(0, len(alts), 3):
+            rows.append(alts[i:i + 3])
         return rows
     compact = field.get("compact") and not is_multi
     _pending: list[dict[str, str]] = []

--- a/adapters/telegram/u1_form_telegram.py
+++ b/adapters/telegram/u1_form_telegram.py
@@ -201,6 +201,21 @@ def _adv_changed_count(form: dict[str, Any], fields: list[dict[str, Any]]) -> in
     return n
 
 
+def _resolved_for_selected_profile(form: dict[str, Any]) -> dict[str, str]:
+    """{advanced_field_id: current value} for the profile currently selected in
+    the form, used to label each control's keep-profile option. Empty when the
+    schema carries no resolved values (offline / older workflow)."""
+    amap = form["schema"].get("advanced_resolved") or {}
+    if not amap:
+        return {}
+    pf = next((f for f in form["schema"]["fields"] if f["id"] == "profile"), None)
+    if pf is None:
+        return {}
+    sel = form["selections"].get("profile")
+    pid = _opt_id(pf["options"][sel]) if sel is not None else pf.get("default")
+    return amap.get(str(pid)) or {}
+
+
 def _screen_of(form: dict[str, Any], fid: str) -> list[dict[str, Any]]:
     """The screen (list of fields) that renders together with ``fid``."""
     for screen in _screens(form):
@@ -292,10 +307,14 @@ def _step_suffix(form: dict[str, Any], fid: str) -> str:
     return f"\n<i>Step {pos + 1} of {len(screens)}</i>"
 
 
-def _field_control_rows(form: dict[str, Any], field: dict[str, Any]) -> list[list[dict[str, str]]]:
+def _field_control_rows(form: dict[str, Any], field: dict[str, Any],
+                        resolved_default: str | None = None) -> list[list[dict[str, str]]]:
     """Option rows (+ pagination, + multi Select-all/Clear) for ONE field.
     Shared by single-field and grouped screens. Callback field indices are
-    ABSOLUTE into schema['fields'] so apply_callback resolves them directly."""
+    ABSOLUTE into schema['fields'] so apply_callback resolves them directly.
+    ``resolved_default`` (advanced controls only): the profile's current value
+    for this field, folded into the "profile default" option so it reads
+    "keep profile (X)"."""
     fi = _field_index(form, field["id"])
     page = form["pages"][field["id"]]
     paginated = len(field["options"]) > PAGE_SIZE
@@ -314,7 +333,10 @@ def _field_control_rows(form: dict[str, Any], field: dict[str, Any]) -> list[lis
         else:
             mark = "● " if sel == oi else "○ "
             cb = f"s:{fi}:{oi}"
-        btn = {"text": f"{mark}{_opt_label(opt)}", "callback_data": cb}
+        _lbl = _opt_label(opt)
+        if resolved_default and _opt_id(opt) == "default":
+            _lbl = _lbl.replace("profile default", f"keep profile ({resolved_default})")
+        btn = {"text": f"{mark}{_lbl}", "callback_data": cb}
         if compact:
             _pending.append(btn)
             if len(_pending) == 2:
@@ -484,9 +506,11 @@ def _render_adv_category(form: dict[str, Any], catkey: str) -> dict[str, Any]:
         return _render_adv_menu(form)
     _key, label, fields = entry
     lines = [f"<b>{_esc(label)}</b>", "Tap to change, then Back to tweaks."]
+    resolved = _resolved_for_selected_profile(form)
     rows: list[list[dict[str, str]]] = []
     for field in fields:
-        rows.extend(_field_control_rows(form, field))
+        rows.extend(_field_control_rows(form, field,
+                                        resolved_default=resolved.get(field["id"])))
     rows.append([
         {"text": "↩ Back to tweaks", "callback_data": "am"},
         {"text": "✖ Cancel", "callback_data": "X"},

--- a/adapters/telegram/u1_form_telegram.py
+++ b/adapters/telegram/u1_form_telegram.py
@@ -35,6 +35,7 @@ from typing import Any
 # Tunables (callers may monkey-patch for tests / different UX).
 PAGE_SIZE = 8                # buttons per screen when a field has > PAGE_SIZE options
 REVIEW_FIELD = "__review__"
+ADV_MENU = "__adv_menu__"  # the tweak category menu (level 1 of the sub-page nav)
 
 
 # --------------------------------------------------------------------------- #
@@ -137,6 +138,69 @@ def _advanced_fields(form: dict[str, Any]) -> list[dict[str, Any]]:
             if _is_screen_field(f) and f.get("advanced")]
 
 
+def _supports_on(form: dict[str, Any]) -> bool:
+    """Is the setup-screen Supports toggle ON? Advanced controls that Orca only
+    honours with supports enabled (support_style) hide when it's off."""
+    f = next((x for x in form["schema"]["fields"] if x["id"] == "supports"), None)
+    if not f:
+        return True  # no supports control on this form → hide nothing
+    sel = form["selections"].get(f["id"])
+    if sel is None:
+        return f.get("default") == "supports"
+    return _opt_id(f["options"][sel]) == "supports"
+
+
+def _adv_field_visible(form: dict[str, Any], field: dict[str, Any]) -> bool:
+    """Whether an advanced control applies given the rest of the form. Keeps
+    dead controls (a support style with supports off) out of the menu."""
+    if field["id"] == "support_style":
+        return _supports_on(form)
+    return True
+
+
+def _category_fields(form: dict[str, Any], catkey: str) -> list[dict[str, Any]]:
+    """Advanced fields tagged ``catkey`` that currently apply, in schema order."""
+    return [f for f in _advanced_fields(form)
+            if f.get("category") == catkey and _adv_field_visible(form, f)]
+
+
+def _adv_categories(form: dict[str, Any]) -> list[tuple[str, str, list[dict[str, Any]]]]:
+    """(key, label, fields) for each advanced category that has visible fields,
+    in the schema's declared order. Any advanced field whose category isn't
+    declared falls into a trailing bucket so nothing is silently unreachable."""
+    out: list[tuple[str, str, list[dict[str, Any]]]] = []
+    declared: set[str] = set()
+    for cat in form["schema"].get("advanced_categories", []):
+        declared.add(cat["key"])
+        fields = _category_fields(form, cat["key"])
+        if fields:
+            out.append((cat["key"], cat["label"], fields))
+    leftover = [f for f in _advanced_fields(form)
+                if f.get("category") not in declared and _adv_field_visible(form, f)]
+    if leftover:
+        out.append(("_more", "⚙ More tweaks", leftover))
+    return out
+
+
+def _adv_bucket_of(form: dict[str, Any], fid: str) -> str | None:
+    """The category-menu bucket key whose page renders field ``fid`` (or None if
+    ``fid`` is not an advanced field)."""
+    for key, _label, fields in _adv_categories(form):
+        if any(f["id"] == fid for f in fields):
+            return key
+    return None
+
+
+def _adv_changed_count(form: dict[str, Any], fields: list[dict[str, Any]]) -> int:
+    """How many of ``fields`` are set to something other than profile default."""
+    n = 0
+    for f in fields:
+        sel = form["selections"].get(f["id"])
+        if sel is not None and _opt_id(f["options"][sel]) != "default":
+            n += 1
+    return n
+
+
 def _screen_of(form: dict[str, Any], fid: str) -> list[dict[str, Any]]:
     """The screen (list of fields) that renders together with ``fid``."""
     for screen in _screens(form):
@@ -190,9 +254,15 @@ def render_screen(form: dict[str, Any]) -> dict[str, Any]:
 
     Returns ``{"text": str, "keyboard": list[list[{"text": str, "callback_data": str}]]}``.
     """
-    if form["current"] == REVIEW_FIELD:
+    cur = form["current"]
+    if cur == REVIEW_FIELD:
         return _render_review(form)
-    screen = _screen_of(form, form["current"])
+    if cur == ADV_MENU:
+        return _render_adv_menu(form)
+    bucket = _adv_bucket_of(form, cur)
+    if bucket is not None:
+        return _render_adv_category(form, bucket)
+    screen = _screen_of(form, cur)
     if len(screen) > 1:
         return _render_group(form, screen)
     return _render_field(form, screen[0])
@@ -356,9 +426,9 @@ def _render_review(form: dict[str, Any]) -> dict[str, Any]:
         if changed:
             lines.append("\u2022 <b>Advanced</b>: " + _esc(", ".join(changed)))
         rows.append([{
-            "text": ("\u2699 Advanced settings"
-                     + (f" ({len(changed)} set)" if changed else "")),
-            "callback_data": f"e:{_field_index(form, adv[0]['id'])}",
+            "text": ("\u2699 Print tweaks"
+                     + (f" ({len(changed)} changed)" if changed else "")),
+            "callback_data": "am",
         }])
 
     # Action becomes the submit verbs: each option submits with that action.
@@ -380,6 +450,47 @@ def _render_review(form: dict[str, Any]) -> dict[str, Any]:
         ])
     lines.append("")
     lines.append("<i>This only slices + uploads and shows you the plate, the review, and a fresh bed photo. Nothing prints until you confirm at the bed-clear step.</i>")
+    return {"text": "\n".join(lines), "keyboard": rows}
+
+
+def _render_adv_menu(form: dict[str, Any]) -> dict[str, Any]:
+    """Level 1 of the tweak sub-pages: the category menu, reached from Review's
+    ⚙ button. Lists only categories that have applicable fields; each shows how
+    many of its controls are set away from the profile default."""
+    lines = ["<b>⚙ Print tweaks</b>",
+             "All optional. Anything you leave alone keeps the profile's value.",
+             ""]
+    rows: list[list[dict[str, str]]] = []
+    for key, label, fields in _adv_categories(form):
+        n = _adv_changed_count(form, fields)
+        text = _esc(label) + (f"  · {n} changed" if n else "")
+        rows.append([{"text": text, "callback_data": f"cat:{key}"}])
+    if _adv_changed_count(form, _advanced_fields(form)):
+        rows.append([{"text": "↩ Reset all to profile", "callback_data": "ar"}])
+    rows.append([
+        {"text": "✅ Done", "callback_data": "ad"},
+        {"text": "✖ Cancel", "callback_data": "X"},
+    ])
+    return {"text": "\n".join(lines), "keyboard": rows}
+
+
+def _render_adv_category(form: dict[str, Any], catkey: str) -> dict[str, Any]:
+    """Level 2: one category's controls as inline radio groups, plus Back. The
+    bucket is resolved through _adv_categories so a category emptied by a
+    conditional (supports off) or a stale cursor bounces cleanly to the menu."""
+    entry = next(((k, l, fs) for k, l, fs in _adv_categories(form) if k == catkey), None)
+    if entry is None:
+        form["current"] = ADV_MENU
+        return _render_adv_menu(form)
+    _key, label, fields = entry
+    lines = [f"<b>{_esc(label)}</b>", "Tap to change, then Back to tweaks."]
+    rows: list[list[dict[str, str]]] = []
+    for field in fields:
+        rows.extend(_field_control_rows(form, field))
+    rows.append([
+        {"text": "↩ Back to tweaks", "callback_data": "am"},
+        {"text": "✖ Cancel", "callback_data": "X"},
+    ])
     return {"text": "\n".join(lines), "keyboard": rows}
 
 
@@ -448,6 +559,29 @@ def _apply_callback_inner(form: dict[str, Any], data: str) -> dict[str, Any]:
             return {"kind": "rerender",
                     "warning": f"Please answer: {_esc(', '.join(missing))}"}
         return {"kind": "submit", "answer": answer_json(form)}
+
+    if kind == "am":              # open / return to the tweak category menu
+        form.pop("_edit_return", None)
+        form["current"] = ADV_MENU
+        return {"kind": "rerender"}
+
+    if kind == "ad":              # Done with tweaks → back to Review
+        form["current"] = REVIEW_FIELD
+        return {"kind": "rerender"}
+
+    if kind == "ar":              # Reset every advanced control to profile default
+        for f in _advanced_fields(form):
+            di = next((i for i, o in enumerate(f["options"])
+                       if _opt_id(o) == "default"), None)
+            if di is not None:
+                form["selections"][f["id"]] = di
+        return {"kind": "rerender"}
+
+    if kind == "cat":             # open a category sub-page
+        catkey = parts[1]
+        bucket = next((fs for k, _l, fs in _adv_categories(form) if k == catkey), None)
+        form["current"] = bucket[0]["id"] if bucket else ADV_MENU
+        return {"kind": "rerender"}
 
     fi = int(parts[1])
     field = fields[fi]

--- a/scripts/u1_form.py
+++ b/scripts/u1_form.py
@@ -165,6 +165,26 @@ _ADVANCED_CATEGORY = {
     "support_style": "supports",
 }
 
+# Bare option labels for the category sub-page. There, each setting has a
+# full-width HEADER (its name + current value), so the option buttons under it
+# don't repeat the setting name — they show only the value ("30%", "gyroid",
+# "3"), which fits three-up without truncation. The full self-describing label
+# is still used everywhere else (text fallback, review summary).
+_ADVANCED_SHORT = {
+    "infill": {"10": "10%", "15": "15%", "20": "20%", "30": "30%",
+               "40": "40%", "50": "50%"},
+    "infill_pattern": {"grid": "grid", "gyroid": "gyroid", "honeycomb": "honeycomb",
+                       "triangles": "triangles", "cubic": "cubic"},
+    "walls": {"2": "2", "3": "3", "4": "4"},
+    "brim": {"off": "off", "auto": "auto"},
+    "fuzzy": {"off": "off", "on": "on"},
+    "top_shell": {"3": "3", "4": "4", "5": "5"},
+    "bottom_shell": {"3": "3", "4": "4"},
+    "one_wall_top": {"off": "off", "on": "on"},
+    "raft": {"off": "off", "small": "3 layers"},
+    "support_style": {"tree": "tree", "grid": "grid"},
+}
+
 
 def _display_resolved(fid: str, raw: Any) -> str:
     """Compress a profile's raw Orca value for an advanced key into the short
@@ -1008,9 +1028,11 @@ def build_form_schema(spec: dict[str, Any], *, submit: dict[str, str] | None = N
     # "default" = no override; skipping the screen is today's behavior.
     if spec.get("offer_advanced"):
         for _fid, _lbl, _opts, _orca_key, _mapping in ADVANCED_FIELDS:
+            _shorts = _ADVANCED_SHORT.get(_fid, {})
             fields.append({
                 "id": _fid, "type": "single_select", "label": _lbl,
-                "options": [{"id": oid, "label": olbl} for oid, olbl in _opts],
+                "options": [{"id": oid, "label": olbl,
+                             "short": _shorts.get(oid, olbl)} for oid, olbl in _opts],
                 "default": "default", "required": False,
                 "advanced": True, "group": "advanced",
                 "group_label": "Advanced settings",

--- a/scripts/u1_form.py
+++ b/scripts/u1_form.py
@@ -165,6 +165,47 @@ _ADVANCED_CATEGORY = {
     "support_style": "supports",
 }
 
+
+def _display_resolved(fid: str, raw: Any) -> str:
+    """Compress a profile's raw Orca value for an advanced key into the short
+    token shown in 'keep profile (X)'. Deliberately small — a display hint, not
+    a parse; anything unrecognized falls back to the raw string."""
+    s = "" if raw is None else str(raw).strip()
+    if fid in ("infill", "infill_pattern", "walls", "top_shell", "bottom_shell"):
+        return s
+    if fid == "brim":
+        return "off" if s in ("", "no_brim") else "on"
+    if fid == "fuzzy":
+        return "off" if s in ("", "none") else "on"
+    if fid == "one_wall_top":
+        return "on" if s in ("1", "true", "True") else "off"
+    if fid == "raft":
+        try:
+            n = int(float(s))
+        except ValueError:
+            n = 0
+        return "off" if n <= 0 else f"{n} layers"
+    if fid == "support_style":
+        return "tree" if "tree" in s else ("grid" if s else "")
+    return s
+
+
+def resolve_advanced_from_profile(flat_process: dict[str, Any]) -> dict[str, str]:
+    """Map a FLATTENED process profile to {advanced_field_id: short current
+    value} so the tweak menu can show what each control changes FROM ('Top
+    layers: keep profile (4)'). Only keys present in the profile are returned;
+    an unread key just leaves that control on the generic 'profile default'
+    label. Pair with u1_slice_workflow._flatten_process_profile to resolve the
+    inherits chain first."""
+    out: dict[str, str] = {}
+    for fid, _lbl, _opts, orca_key, _mapping in ADVANCED_FIELDS:
+        if orca_key in flat_process:
+            val = _display_resolved(fid, flat_process.get(orca_key))
+            if val != "":
+                out[fid] = val
+    return out
+
+
 # Quantity (v2.3): print N copies of a SINGLE-part job. The workflow sets
 # spec["offer_quantity"] only when the kit has one part — per-part quantities
 # on multi-part kits are out of scope (the operator picks parts instead). The
@@ -992,6 +1033,13 @@ def build_form_schema(spec: dict[str, Any], *, submit: dict[str, str] | None = N
         # from this + each field's "category", so it needs no form internals).
         schema["advanced_categories"] = [{"key": k, "label": l}
                                          for k, l in ADVANCED_CATEGORIES]
+        # Per-profile current values (keyed by str(profile idx)) so the tweak
+        # controls can show "keep profile (X)" for whichever profile is picked.
+        # The workflow resolves these (it holds the profile paths); absent it,
+        # the labels simply stay generic.
+        _resolved = spec.get("advanced_resolved")
+        if _resolved:
+            schema["advanced_resolved"] = {str(k): v for k, v in _resolved.items()}
     if submit:
         schema["submit"] = submit
     return schema

--- a/scripts/u1_form.py
+++ b/scripts/u1_form.py
@@ -118,6 +118,24 @@ ADVANCED_FIELDS = (
      [("default", "Fuzzy skin: profile default"), ("off", "Fuzzy skin: off"),
       ("on", "Fuzzy skin: on (outer walls)")],
      "fuzzy_skin", {"off": "none", "on": "external"}),
+    ("top_shell", "Top layers",
+     [("default", "Top layers: profile default"), ("3", "Top layers: 3"),
+      ("4", "Top layers: 4"), ("5", "Top layers: 5")],
+     "top_shell_layers", {"3": "3", "4": "4", "5": "5"}),
+    ("bottom_shell", "Bottom layers",
+     [("default", "Bottom layers: profile default"), ("3", "Bottom layers: 3"),
+      ("4", "Bottom layers: 4")],
+     "bottom_shell_layers", {"3": "3", "4": "4"}),
+    # only_one_wall_top is Orca's dedicated top-surface control — NEVER expose a
+    # global wall_loops=1, which would weaken the whole part on a mis-tap.
+    ("one_wall_top", "One wall on top",
+     [("default", "One wall on top: profile default"),
+      ("off", "One wall on top: off"), ("on", "One wall on top: on")],
+     "only_one_wall_top", {"off": "0", "on": "1"}),
+    ("raft", "Raft",
+     [("default", "Raft: profile default"), ("off", "Raft: off"),
+      ("small", "Raft: 3 layers")],
+     "raft_layers", {"off": "0", "small": "3"}),
     # Only takes effect when Supports is ON (the setup-screen toggle);
     # Orca ignores support_type when enable_support is 0.
     ("support_style", "Support style",
@@ -129,6 +147,23 @@ ADVANCED_FIELDS = (
 
 _ADVANCED_BY_ID = {fid: (orca_key, mapping)
                    for fid, _lbl, _opts, orca_key, mapping in ADVANCED_FIELDS}
+
+# The tweak menu groups advanced controls into category sub-pages so the screen
+# isn't one long flat list. Order here is the category page order; the menu only
+# lists categories that actually have fields.
+ADVANCED_CATEGORIES = (
+    ("strength", "\U0001f9f1 Strength & shells"),
+    ("first_layer", "\U0001f321️ First layer & adhesion"),
+    ("finish", "✨ Surface finish"),
+    ("supports", "\U0001fa9c Supports"),
+)
+_ADVANCED_CATEGORY = {
+    "walls": "strength", "top_shell": "strength", "bottom_shell": "strength",
+    "one_wall_top": "strength", "infill": "strength", "infill_pattern": "strength",
+    "brim": "first_layer", "raft": "first_layer",
+    "fuzzy": "finish",
+    "support_style": "supports",
+}
 
 # Quantity (v2.3): print N copies of a SINGLE-part job. The workflow sets
 # spec["offer_quantity"] only when the kit has one part — per-part quantities
@@ -938,6 +973,7 @@ def build_form_schema(spec: dict[str, Any], *, submit: dict[str, str] | None = N
                 "default": "default", "required": False,
                 "advanced": True, "group": "advanced",
                 "group_label": "Advanced settings",
+                "category": _ADVANCED_CATEGORY.get(_fid, "finish"),
             })
     # v2.2 (kit refinement): NO action field. The form only collects the PLAN.
     # The single print/keep-staged decision happens AFTER slice + a FRESH bed
@@ -951,6 +987,11 @@ def build_form_schema(spec: dict[str, Any], *, submit: dict[str, str] | None = N
         "text_fallback": build_form(spec),
         "answer_grammar": "pipe-separated one-liner: parts 1,3 | T0 | PLA | profile 2 | no-supports",
     }
+    if spec.get("offer_advanced"):
+        # Category order + labels for the tweak menu (renderer builds the menu
+        # from this + each field's "category", so it needs no form internals).
+        schema["advanced_categories"] = [{"key": k, "label": l}
+                                         for k, l in ADVANCED_CATEGORIES]
     if submit:
         schema["submit"] = submit
     return schema

--- a/scripts/u1_kit_workflow.py
+++ b/scripts/u1_kit_workflow.py
@@ -2030,6 +2030,10 @@ def _build_form_spec(kit: dict[str, Any], nozzle: str,
     calls could silently shift what ``profile 2`` means. Verified 2026-06-28:
     list_profiles order changes when history_print_settings_id changes.
     """
+    # Per-profile current advanced values for the tweak menu's "keep profile
+    # (X)" labels. Only filled on a fresh build (the persisted/answer path holds
+    # no profile paths and renders no form). Display-only; fully guarded.
+    _adv_resolved: dict[str, dict[str, str]] = {}
     if persisted_profiles:
         profiles_full = [
             {"idx": int(p["idx"]), "value": p["value"], "label": p.get("label", p["value"]),
@@ -2060,6 +2064,25 @@ def _build_form_spec(kit: dict[str, Any], nozzle: str,
              "recommended": bool(o.get("recommended"))}
             for i, o in enumerate(prof_opts)
         ]
+        # Resolve each profile's CURRENT advanced values so the tweak menu can
+        # show "keep profile (X)". Uses the picker's per-profile path and
+        # flattens the inherits chain; display-only and fully guarded, so any
+        # read failure just leaves that control on the generic label.
+        try:
+            import u1_slice_workflow as _sw
+            for i, o in enumerate(prof_opts):
+                _p = o.get("path")
+                if not _p:
+                    continue
+                try:
+                    _flat = _sw._flatten_process_profile(Path(_p))
+                    _vals = u1_form.resolve_advanced_from_profile(_flat)
+                    if _vals:
+                        _adv_resolved[str(i + 1)] = _vals
+                except Exception:
+                    continue
+        except Exception:
+            pass
     parts = [
         {"id": p["part_id"], "label": f"{p['filename']} ({p['footprint_mm'][0]:.0f}x{p['footprint_mm'][1]:.0f}mm)"}
         for p in kit["parts"]
@@ -2096,6 +2119,9 @@ def _build_form_spec(kit: dict[str, Any], nozzle: str,
         # fuzzy skin) — reachable only from the form's Review button; the
         # default path never sees it.
         "offer_advanced": True,
+        # Per-profile current advanced values for the tweak menu (empty on the
+        # persisted/answer path, which renders no form).
+        "advanced_resolved": _adv_resolved,
     }
     # v2.3: quantity (print N copies) — offered ONLY for single-part jobs.
     # Multi-part kits keep per-part quantities out of scope; the operator

--- a/scripts/u1_kit_workflow.py
+++ b/scripts/u1_kit_workflow.py
@@ -2034,12 +2034,21 @@ def _build_form_spec(kit: dict[str, Any], nozzle: str,
     # (X)" labels. Only filled on a fresh build (the persisted/answer path holds
     # no profile paths and renders no form). Display-only; fully guarded.
     _adv_resolved: dict[str, dict[str, str]] = {}
+    _slug_to_path: dict[str, str] = {}
     if persisted_profiles:
         profiles_full = [
             {"idx": int(p["idx"]), "value": p["value"], "label": p.get("label", p["value"]),
              "recommended": bool(p.get("recommended"))}
             for p in persisted_profiles
         ]
+        # Persisted profiles carry no path; re-derive slug->path for the resolve
+        # step below. History order doesn't matter here (we only need the paths),
+        # so this deliberately does NOT pass history_print_settings_id.
+        try:
+            _slug_to_path = {o["value"]: o.get("path")
+                             for o in list_profiles(nozzle=nozzle)}
+        except Exception:
+            _slug_to_path = {}
     else:
         # Building the profile list fresh -> first pull the operator's recent
         # prints off the printer into profiles/from-printer/ so what they've
@@ -2064,25 +2073,33 @@ def _build_form_spec(kit: dict[str, Any], nozzle: str,
              "recommended": bool(o.get("recommended"))}
             for i, o in enumerate(prof_opts)
         ]
-        # Resolve each profile's CURRENT advanced values so the tweak menu can
-        # show "keep profile (X)". Uses the picker's per-profile path and
-        # flattens the inherits chain; display-only and fully guarded, so any
-        # read failure just leaves that control on the generic label.
-        try:
-            import u1_slice_workflow as _sw
-            for i, o in enumerate(prof_opts):
-                _p = o.get("path")
-                if not _p:
-                    continue
-                try:
-                    _flat = _sw._flatten_process_profile(Path(_p))
-                    _vals = u1_form.resolve_advanced_from_profile(_flat)
-                    if _vals:
-                        _adv_resolved[str(i + 1)] = _vals
-                except Exception:
-                    continue
-        except Exception:
-            pass
+        # prof_opts already carries each profile's path — reuse it, no 2nd scan
+        # (a 2nd list_profiles here would also drop the history preset).
+        _slug_to_path = {o["value"]: o.get("path") for o in prof_opts}
+    # Resolve each OFFERED profile's current advanced values so the tweak menu
+    # can show "keep profile (X)". Runs for BOTH paths — the fresh build AND the
+    # persisted-profiles emit path. The form-emit call passes persisted profiles
+    # (for index stability across the emit/answer turns), so this MUST NOT live
+    # only in the fresh branch, or the emitted form loses its resolved values
+    # (live 2026-07-15: the operator's form showed "profile default" everywhere).
+    # Map each profile's slug to its process JSON exactly as the slicer does,
+    # flatten the inherits chain, and read the advanced keys. Display-only and
+    # fully guarded.
+    try:
+        import u1_slice_workflow as _sw
+        for _p in profiles_full:
+            _pth = _slug_to_path.get(_p.get("value"))
+            if not _pth:
+                continue
+            try:
+                _flat = _sw._flatten_process_profile(Path(_pth))
+                _vals = u1_form.resolve_advanced_from_profile(_flat)
+                if _vals:
+                    _adv_resolved[str(_p["idx"])] = _vals
+            except Exception:
+                continue
+    except Exception:
+        pass
     parts = [
         {"id": p["part_id"], "label": f"{p['filename']} ({p['footprint_mm'][0]:.0f}x{p['footprint_mm'][1]:.0f}mm)"}
         for p in kit["parts"]

--- a/scripts/u1_slice_workflow.py
+++ b/scripts/u1_slice_workflow.py
@@ -929,7 +929,8 @@ def apply_supports_override(process_path: Path, enable_support: bool, out_dir: P
 # the reliable path is a flattened, self-contained temp process JSON.
 ADVANCED_OVERRIDE_KEYS = (
     'sparse_infill_density', 'sparse_infill_pattern', 'wall_loops',
-    'brim_type', 'fuzzy_skin', 'support_type',
+    'top_shell_layers', 'bottom_shell_layers', 'only_one_wall_top',
+    'brim_type', 'raft_layers', 'fuzzy_skin', 'support_type',
 )
 
 

--- a/tests/test_advanced_overrides_e2e.py
+++ b/tests/test_advanced_overrides_e2e.py
@@ -38,7 +38,11 @@ OVERRIDES = {
     "sparse_infill_density": "30%",
     "sparse_infill_pattern": "gyroid",
     "wall_loops": "3",
+    "top_shell_layers": "5",
+    "bottom_shell_layers": "4",
+    "only_one_wall_top": "1",
     "brim_type": "auto_brim",
+    "raft_layers": "3",
     "fuzzy_skin": "external",
     "support_type": "tree(auto)",
 }

--- a/tests/test_advanced_settings.py
+++ b/tests/test_advanced_settings.py
@@ -361,6 +361,30 @@ def test_tweak_menu_keep_profile_value_follows_selected_profile():
     assert not any("keep profile (2)" in t for t in txts2)
 
 
+def test_build_form_spec_resolves_advanced_on_the_persisted_emit_path(monkeypatch):
+    """The form-EMIT call passes persisted profiles (index stability), so the
+    resolved "keep profile (X)" values must be computed on that path too, not
+    only the fresh build. Live 2026-07-15: the emitted form showed "profile
+    default" everywhere because resolution lived only in the fresh branch."""
+    import u1_kit_workflow as kw
+    fake = [{"value": "p_a", "path": "/x/a.json", "label": "A", "recommended": True},
+            {"value": "p_b", "path": "/x/b.json", "label": "B", "recommended": False}]
+    monkeypatch.setattr(kw, "list_profiles", lambda **k: fake)
+    monkeypatch.setattr(sw, "_flatten_process_profile",
+                        lambda p, **k: {"wall_loops": "3", "sparse_infill_density": "20%"})
+    kit = {"parts": [{"part_id": "p1", "filename": "a.stl", "footprint_mm": (10, 10)}]}
+    persisted = [{"idx": 1, "value": "p_a", "label": "A", "recommended": True},
+                 {"idx": 2, "value": "p_b", "label": "B", "recommended": False}]
+    spec = kw._build_form_spec(kit, "0.4", persisted_profiles=persisted,
+                              refresh=False, scrub=False)
+    assert spec["advanced_resolved"] == {
+        "1": {"walls": "3", "infill": "20%"},
+        "2": {"walls": "3", "infill": "20%"}}
+    # and it survives into the schema
+    schema = u1_form.build_form_schema(spec)
+    assert schema["advanced_resolved"]["1"]["walls"] == "3"
+
+
 def test_tweak_menu_keep_profile_label_absent_without_resolved():
     # No advanced_resolved in the schema -> the generic "profile default" stands.
     schema = u1_form.build_form_schema(_spec())

--- a/tests/test_advanced_settings.py
+++ b/tests/test_advanced_settings.py
@@ -72,7 +72,9 @@ def test_supports_override_forces_exclude_object_for_m486_previews(tmp_path):
 def test_schema_offers_advanced_fields_flagged():
     schema = u1_form.build_form_schema(_spec())
     adv = [f for f in schema["fields"] if f.get("advanced")]
-    assert [f["id"] for f in adv] == ["infill", "infill_pattern", "walls", "brim", "fuzzy", "support_style"]
+    assert [f["id"] for f in adv] == ["infill", "infill_pattern", "walls", "brim", "fuzzy",
+                                      "top_shell", "bottom_shell", "one_wall_top", "raft",
+                                      "support_style"]
     assert all(f["group"] == "advanced" and f["default"] == "default" for f in adv)
     # not offered -> absent entirely
     schema2 = u1_form.build_form_schema(_spec(offer=False))
@@ -184,7 +186,9 @@ def test_advanced_buttons_self_describing_and_review_not_duplicated():
     # and each label identifies its field (no bare values)
     for f in tg._advanced_fields(form):
         key = {"infill": "Infill", "infill_pattern": "Pattern", "walls": "Walls",
-               "brim": "Brim", "fuzzy": "Fuzzy", "support_style": "Support"}[f["id"]]
+               "brim": "Brim", "fuzzy": "Fuzzy", "support_style": "Support",
+               "top_shell": "Top", "bottom_shell": "Bottom",
+               "one_wall_top": "One wall", "raft": "Raft"}[f["id"]]
         assert all(key in tg._opt_label(o) for o in f["options"]), f["id"]
     # Review: exactly ONE advanced-related button (the jump), no Edit rows
     form["current"] = tg.REVIEW_FIELD

--- a/tests/test_advanced_settings.py
+++ b/tests/test_advanced_settings.py
@@ -385,6 +385,19 @@ def test_build_form_spec_resolves_advanced_on_the_persisted_emit_path(monkeypatc
     assert schema["advanced_resolved"]["1"]["walls"] == "3"
 
 
+def test_advanced_category_packs_options_not_one_per_row():
+    """The category sub-page must pack options into a block, not stack one button
+    per row (live 2026-07-15: the flat one-per-row list read as "a fat chunk of
+    info, lazily stacked"). Each setting's alternatives ride multi-button rows."""
+    schema = u1_form.build_form_schema(_spec())
+    form = tg.new_form(schema)
+    form["current"] = "infill"  # a Strength & shells control
+    kb = tg.render_screen(form)["keyboard"]
+    packed = [r for r in kb
+              if len(r) >= 2 and all(b["callback_data"].startswith("s:") for b in r)]
+    assert packed, "advanced options must be packed two-up, not one per row"
+
+
 def test_tweak_menu_keep_profile_label_absent_without_resolved():
     # No advanced_resolved in the schema -> the generic "profile default" stands.
     schema = u1_form.build_form_schema(_spec())

--- a/tests/test_advanced_settings.py
+++ b/tests/test_advanced_settings.py
@@ -398,6 +398,26 @@ def test_advanced_category_packs_options_not_one_per_row():
     assert packed, "advanced options must be packed two-up, not one per row"
 
 
+def test_advanced_category_uses_bare_values_under_a_header():
+    """Under each setting's full-width header, the option buttons show the BARE
+    value ("30%", "gyroid", "2") three-up, not the repeated setting name (live
+    2026-07-15: "Infill 10%" on every button doubled the text and truncated
+    wider labels). The header carries the setting name + current value."""
+    schema = u1_form.build_form_schema(_spec())
+    form = tg.new_form(schema)
+    form["current"] = "infill"
+    kb = tg.render_screen(form)["keyboard"]
+    header = kb[0]
+    assert len(header) == 1 and "Infill" in header[0]["text"]  # header names the setting
+    value_rows = [r for r in kb[1:]
+                  if r and all(b["callback_data"].startswith("s:") for b in r)]
+    assert any(len(r) >= 2 for r in value_rows), "values should pack multi-up"
+    for r in value_rows:
+        assert len(r) <= 3, "at most three-up"
+        for b in r:
+            assert "Infill" not in b["text"], f"option repeats setting name: {b['text']}"
+
+
 def test_tweak_menu_keep_profile_label_absent_without_resolved():
     # No advanced_resolved in the schema -> the generic "profile default" stands.
     schema = u1_form.build_form_schema(_spec())

--- a/tests/test_advanced_settings.py
+++ b/tests/test_advanced_settings.py
@@ -141,17 +141,17 @@ def test_renderer_advanced_reached_via_two_level_tweak_menu():
     # flat field jump).
     form["current"] = tg.REVIEW_FIELD
     kb = tg.render_screen(form)["keyboard"]
-    tweak_btn = next(b for row in kb for b in row if "tweaks" in b["text"].lower())
-    assert tweak_btn["callback_data"] == "am"
+    tweak_btn = next(b for row in kb for b in row if "Advanced options" in b["text"])
+    assert tweak_btn["callback_data"] == "g:m"
     tg.apply_callback(form, tweak_btn["callback_data"])
     assert form["current"] == tg.ADV_MENU
     menu = tg.render_screen(form)
     cats = [b["callback_data"] for row in menu["keyboard"] for b in row
-            if b["callback_data"].startswith("cat:")]
-    assert "cat:strength" in cats and "cat:finish" in cats
+            if b["callback_data"].startswith("g:c:")]
+    assert "g:c:strength" in cats and "g:c:finish" in cats
     # open Strength & shells -> lands on the first strength control; the page
     # shows ONLY that category's fields, not the whole advanced list
-    tg.apply_callback(form, "cat:strength")
+    tg.apply_callback(form, "g:c:strength")
     assert form["current"] == "infill"
     page = tg.render_screen(form)
     assert "Strength" in page["text"]
@@ -164,13 +164,13 @@ def test_renderer_advanced_reached_via_two_level_tweak_menu():
     tg.apply_callback(form, f"s:{fi}:{gy}")
     assert form["current"] == "infill"  # still on the strength page
     # Back to the menu -> the strength row now shows its changed count
-    tg.apply_callback(form, "am")
+    tg.apply_callback(form, "g:m")
     assert form["current"] == tg.ADV_MENU
     menu2 = tg.render_screen(form)
-    assert any(b["callback_data"] == "cat:strength" and "1 changed" in b["text"]
+    assert any(b["callback_data"] == "g:c:strength" and "1 changed" in b["text"]
                for row in menu2["keyboard"] for b in row)
     # Done -> Review; the change shows in the summary line + button count
-    tg.apply_callback(form, "ad")
+    tg.apply_callback(form, "g:d")
     assert form["current"] == tg.REVIEW_FIELD
     review = tg.render_screen(form)
     assert "Pattern: gyroid" in review["text"]
@@ -218,15 +218,15 @@ def test_advanced_buttons_self_describing_and_review_not_duplicated():
     for row in review["keyboard"]:
         for b in row:
             cd = b.get("callback_data", "")
-            if cd == "am":
+            if cd == "g:m":
                 menu_buttons += 1
             elif cd.startswith("e:"):
                 fi = int(cd.split(":")[1])
                 edit_targets.append(form["schema"]["fields"][fi]["id"])
-    assert menu_buttons == 1  # the single tweak-menu jump
+    assert menu_buttons == 1  # the single advanced-options jump
     assert not any(t in adv_ids for t in edit_targets)  # no advanced Edit rows
-    assert not any("Infill" in b["text"] and "tweaks" not in b["text"].lower()
-                   for row in review["keyboard"] for b in row)
+    # no raw advanced control (e.g. an "Infill" option button) leaks onto Review
+    assert not any("Infill" in b["text"] for row in review["keyboard"] for b in row)
 
 
 def test_tweak_menu_conditional_supports_and_reset():
@@ -249,9 +249,58 @@ def test_tweak_menu_conditional_supports_and_reset():
                  if tg._opt_id(o) == "3")
     tg.apply_callback(form, f"s:{wfi}:{three}")
     assert tg._adv_changed_count(form, tg._advanced_fields(form)) >= 1
-    tg.apply_callback(form, "ar")
+    tg.apply_callback(form, "g:r")
     assert tg._adv_changed_count(form, tg._advanced_fields(form)) == 0
     assert tg.answer_json(form)["walls"] == "default"
+
+
+def test_every_renderer_callback_is_routable_by_the_gateway():
+    """Guard the live gap that shipped 2026-07-15: the tweak-menu buttons used
+    callbacks (am/cat:...) the gateway's FORM_CB_PATTERN didn't route, so a tap
+    only highlighted and nothing opened. Every callback the renderer can emit
+    MUST match that pattern (or a button is dead on Telegram). Unit tests that
+    call apply_callback directly can't catch this, so assert it structurally."""
+    import re
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent
+                           / "adapters" / "hermes" / "plugin"))
+    import telegram_patch as tp  # noqa: E402
+    form_re = re.compile(tp.FORM_CB_PATTERN)
+
+    spec = _spec()
+    # >8 profiles so the profile screen paginates (exercises the page controls)
+    spec["profiles"] = [{"idx": i, "label": f"P{i}"} for i in range(1, 13)]
+    spec["advanced_resolved"] = {"1": {"walls": "2"}}
+    schema = u1_form.build_form_schema(spec)
+    form = tg.new_form(schema)
+    form["selections"]["profile"] = 0  # surfaces the single-select Continue button
+
+    seen: set[str] = set()
+
+    def _collect(screen):
+        for row in screen["keyboard"]:
+            for b in row:
+                seen.add(b["callback_data"])
+
+    # every field screen (groups + single + multi + the paginated profile pages)
+    for f in form["schema"]["fields"]:
+        if tg._is_screen_field(f):
+            form["current"] = f["id"]
+            _collect(tg.render_screen(form))
+    form["current"] = "profile"
+    for pg in range(3):
+        form["pages"]["profile"] = pg
+        _collect(tg.render_screen(form))
+    # review + advanced-options menu + every category page
+    form["current"] = tg.REVIEW_FIELD
+    _collect(tg.render_screen(form))
+    form["current"] = tg.ADV_MENU
+    _collect(tg.render_screen(form))
+    for key, _l, _f in tg._adv_categories(form):
+        tg.apply_callback(form, f"g:c:{key}")
+        _collect(tg.render_screen(form))
+
+    unrouted = sorted(cd for cd in seen if not form_re.match(cd))
+    assert not unrouted, f"gateway FORM_CB_PATTERN would not route: {unrouted}"
 
 
 # ---------- resolved profile values ("keep profile (X)") ----------

--- a/tests/test_advanced_settings.py
+++ b/tests/test_advanced_settings.py
@@ -132,31 +132,49 @@ def test_text_advanced_ignored_when_not_offered():
 
 # ---------- renderer ----------
 
-def test_renderer_advanced_hidden_from_linear_flow_but_reachable():
+def test_renderer_advanced_reached_via_two_level_tweak_menu():
     schema = u1_form.build_form_schema(_spec())
     form = tg.new_form(schema)
     flow_ids = [f["id"] for sc in tg._screens(form) for f in sc]
     assert "infill" not in flow_ids and "fuzzy" not in flow_ids
-    # Review shows the Advanced button; tapping it jumps to the advanced group
+    # Review shows ONE Print-tweaks button that opens the category MENU (not a
+    # flat field jump).
     form["current"] = tg.REVIEW_FIELD
     kb = tg.render_screen(form)["keyboard"]
-    adv_btn = next(b for row in kb for b in row if "Advanced" in b["text"])
-    tg.apply_callback(form, adv_btn["callback_data"])
-    assert form["current"] == "infill" and form.get("_edit_return")
-    screen = tg.render_screen(form)
-    assert "Advanced settings" in screen["text"]
-    # pick gyroid (a grouped radio: marks, doesn't advance)
+    tweak_btn = next(b for row in kb for b in row if "tweaks" in b["text"].lower())
+    assert tweak_btn["callback_data"] == "am"
+    tg.apply_callback(form, tweak_btn["callback_data"])
+    assert form["current"] == tg.ADV_MENU
+    menu = tg.render_screen(form)
+    cats = [b["callback_data"] for row in menu["keyboard"] for b in row
+            if b["callback_data"].startswith("cat:")]
+    assert "cat:strength" in cats and "cat:finish" in cats
+    # open Strength & shells -> lands on the first strength control; the page
+    # shows ONLY that category's fields, not the whole advanced list
+    tg.apply_callback(form, "cat:strength")
+    assert form["current"] == "infill"
+    page = tg.render_screen(form)
+    assert "Strength" in page["text"]
+    assert any("Pattern" in b["text"] for row in page["keyboard"] for b in row)
+    assert not any("Fuzzy" in b["text"] for row in page["keyboard"] for b in row)
+    # pick gyroid (a radio: marks, stays on the category page)
     fi = tg._field_index(form, "infill_pattern")
     gy = next(i for i, o in enumerate(tg._field(form, "infill_pattern")["options"])
               if tg._opt_id(o) == "gyroid")
     tg.apply_callback(form, f"s:{fi}:{gy}")
-    assert form["current"] == "infill"  # still on the advanced screen
-    # group Next returns to Review; summary line shows the change
-    tg.apply_callback(form, f"n:{tg._field_index(form, 'infill')}")
+    assert form["current"] == "infill"  # still on the strength page
+    # Back to the menu -> the strength row now shows its changed count
+    tg.apply_callback(form, "am")
+    assert form["current"] == tg.ADV_MENU
+    menu2 = tg.render_screen(form)
+    assert any(b["callback_data"] == "cat:strength" and "1 changed" in b["text"]
+               for row in menu2["keyboard"] for b in row)
+    # Done -> Review; the change shows in the summary line + button count
+    tg.apply_callback(form, "ad")
     assert form["current"] == tg.REVIEW_FIELD
     review = tg.render_screen(form)
     assert "Pattern: gyroid" in review["text"]
-    assert any("(1 set)" in b["text"] for row in review["keyboard"] for b in row)
+    assert any("(1 changed)" in b["text"] for row in review["keyboard"] for b in row)
 
 
 def test_renderer_answer_json_carries_advanced_ids():
@@ -190,20 +208,50 @@ def test_advanced_buttons_self_describing_and_review_not_duplicated():
                "top_shell": "Top", "bottom_shell": "Bottom",
                "one_wall_top": "One wall", "raft": "Raft"}[f["id"]]
         assert all(key in tg._opt_label(o) for o in f["options"]), f["id"]
-    # Review: exactly ONE advanced-related button (the jump), no Edit rows
+    # Review: exactly ONE advanced-related button (opens the tweak menu), and
+    # NO per-advanced-field Edit rows.
     form["current"] = tg.REVIEW_FIELD
     review = tg.render_screen(form)
     adv_ids = {f["id"] for f in tg._advanced_fields(form)}
     edit_targets = []
+    menu_buttons = 0
     for row in review["keyboard"]:
         for b in row:
             cd = b.get("callback_data", "")
-            if cd.startswith("e:"):
+            if cd == "am":
+                menu_buttons += 1
+            elif cd.startswith("e:"):
                 fi = int(cd.split(":")[1])
                 edit_targets.append(form["schema"]["fields"][fi]["id"])
-    assert sum(1 for t in edit_targets if t in adv_ids) == 1  # the one jump button
-    assert not any(f"Infill" in b["text"] and "Advanced" not in b["text"]
+    assert menu_buttons == 1  # the single tweak-menu jump
+    assert not any(t in adv_ids for t in edit_targets)  # no advanced Edit rows
+    assert not any("Infill" in b["text"] and "tweaks" not in b["text"].lower()
                    for row in review["keyboard"] for b in row)
+
+
+def test_tweak_menu_conditional_supports_and_reset():
+    """The Supports category only appears when the setup Supports toggle is ON
+    (Orca ignores support_type otherwise), and Reset-all returns every advanced
+    control to profile default."""
+    schema = u1_form.build_form_schema(_spec())
+    form = tg.new_form(schema)
+    # supports defaults OFF -> the Supports category has no applicable field
+    assert "supports" not in [k for k, _l, _f in tg._adv_categories(form)]
+    # turn supports ON via its setup field -> the category becomes available
+    sfi = tg._field_index(form, "supports")
+    on = next(i for i, o in enumerate(tg._field(form, "supports")["options"])
+              if tg._opt_id(o) == "supports")
+    tg.apply_callback(form, f"s:{sfi}:{on}")
+    assert "supports" in [k for k, _l, _f in tg._adv_categories(form)]
+    # set a tweak, confirm it counts, then Reset-all clears it
+    wfi = tg._field_index(form, "walls")
+    three = next(i for i, o in enumerate(tg._field(form, "walls")["options"])
+                 if tg._opt_id(o) == "3")
+    tg.apply_callback(form, f"s:{wfi}:{three}")
+    assert tg._adv_changed_count(form, tg._advanced_fields(form)) >= 1
+    tg.apply_callback(form, "ar")
+    assert tg._adv_changed_count(form, tg._advanced_fields(form)) == 0
+    assert tg.answer_json(form)["walls"] == "default"
 
 
 

--- a/tests/test_advanced_settings.py
+++ b/tests/test_advanced_settings.py
@@ -254,6 +254,74 @@ def test_tweak_menu_conditional_supports_and_reset():
     assert tg.answer_json(form)["walls"] == "default"
 
 
+# ---------- resolved profile values ("keep profile (X)") ----------
+
+def test_resolve_advanced_from_profile_maps_scalars():
+    flat = {
+        "sparse_infill_density": "15%", "sparse_infill_pattern": "grid",
+        "wall_loops": "2", "top_shell_layers": "4", "bottom_shell_layers": "3",
+        "only_one_wall_top": "0", "brim_type": "no_brim", "raft_layers": "0",
+        "fuzzy_skin": "none", "support_type": "tree(auto)",
+    }
+    r = u1_form.resolve_advanced_from_profile(flat)
+    assert r == {"infill": "15%", "infill_pattern": "grid", "walls": "2",
+                 "top_shell": "4", "bottom_shell": "3", "one_wall_top": "off",
+                 "brim": "off", "raft": "off", "fuzzy": "off",
+                 "support_style": "tree"}
+    # non-default raw values surface too; an absent key is simply omitted
+    assert u1_form.resolve_advanced_from_profile(
+        {"raft_layers": "3", "only_one_wall_top": "1", "fuzzy_skin": "external"}
+    ) == {"raft": "3 layers", "one_wall_top": "on", "fuzzy": "on"}
+    assert u1_form.resolve_advanced_from_profile({}) == {}
+
+
+def test_schema_carries_advanced_resolved_keyed_by_str_idx():
+    spec = _spec()
+    spec["profiles"] = [{"idx": 1, "label": "A"}, {"idx": 2, "label": "B"}]
+    spec["advanced_resolved"] = {1: {"walls": "2"}, 2: {"walls": "4"}}
+    schema = u1_form.build_form_schema(spec)
+    assert schema["advanced_resolved"] == {"1": {"walls": "2"}, "2": {"walls": "4"}}
+    # not offered -> key absent
+    assert "advanced_resolved" not in u1_form.build_form_schema(_spec(offer=False))
+
+
+def test_tweak_menu_keep_profile_value_follows_selected_profile():
+    spec = _spec()
+    spec["profiles"] = [{"idx": 1, "label": "0.20 Std"}, {"idx": 2, "label": "0.28 Draft"}]
+    spec["advanced_resolved"] = {"1": {"walls": "2", "infill": "15%"},
+                                 "2": {"walls": "4", "infill": "25%"}}
+    schema = u1_form.build_form_schema(spec)
+    form = tg.new_form(schema)
+    pfi = tg._field_index(form, "profile")
+
+    def _pick_profile(idx_str):
+        oi = next(i for i, o in enumerate(tg._field(form, "profile")["options"])
+                  if str(tg._opt_id(o)) == idx_str)
+        tg.apply_callback(form, f"s:{pfi}:{oi}")
+
+    _pick_profile("1")
+    form["current"] = "walls"  # a Strength & shells control
+    txts = [b["text"] for row in tg.render_screen(form)["keyboard"] for b in row]
+    assert any("keep profile (2)" in t for t in txts)
+    assert any("keep profile (15%)" in t for t in txts)
+    # switch profile -> the keep-profile values track the new selection
+    _pick_profile("2")
+    form["current"] = "walls"
+    txts2 = [b["text"] for row in tg.render_screen(form)["keyboard"] for b in row]
+    assert any("keep profile (4)" in t for t in txts2)
+    assert not any("keep profile (2)" in t for t in txts2)
+
+
+def test_tweak_menu_keep_profile_label_absent_without_resolved():
+    # No advanced_resolved in the schema -> the generic "profile default" stands.
+    schema = u1_form.build_form_schema(_spec())
+    form = tg.new_form(schema)
+    form["current"] = "walls"
+    txts = [b["text"] for row in tg.render_screen(form)["keyboard"] for b in row]
+    assert any("Walls: profile default" in t for t in txts)
+    assert not any("keep profile" in t for t in txts)
+
+
 
 def test_support_style_tree_vs_grid():
     """v2.3: tree vs grid support style rides the advanced-override rail."""


### PR DESCRIPTION
## Highlights

- **Advanced options are organized into categories.** Instead of one long screen of every control, Review opens a short menu (Strength & shells, First layer & adhesion, Surface finish, Supports), and each category opens a page with just its controls.
- **Every control shows the profile's current value.** Each setting has a header like "Infill: keep profile (25%)" so you can see what you'd change before you change it. The value tracks whichever profile is selected.
- **Cleaner per-setting layout.** Each setting is a titled header with its options laid out three across ("30%", "gyroid", "2"), with no repeated labels and no truncation.

## Also

- The Supports category only appears when supports are on.
- "Reset all to profile" clears every tweak at once, and Review shows a one-line summary of what changed.
- The profile step gained a Continue button, so a pre-selected profile confirms with a tap instead of paging to the next set.

## New controls

Separate top/bottom shell layers, one-wall-on-top, and raft, on top of the existing infill, pattern, walls, brim, and fuzzy skin.

## Notes

- Profile values are read by flattening each profile's inheritance chain, the same way the slicer resolves them.
- No change to the print-start safety path. This is form and UI only.
- Full test suite green (1026 passed, 8 skipped).
