### PR TITLE
v3.0.0: toolpath-truth review images and upgrade-durable Hermes integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [3.0.0] — 2026-07-22
+
+No breaking changes and nothing to migrate; existing installs just get
+better. The major marks two step changes: review images now show the ground
+truth of what will print, and the toolkit's Hermes integration survives
+Hermes upgrades.
+
+### Added
+
+- **Review images drawn from the real toolpaths.** Both the top-down plate
+  view and the 3D view are now rendered straight from the sliced G-code the
+  printer will run: supports in their own color, the true print pose, real
+  per-layer geometry, and matching part colors across both images. Nothing
+  is re-sliced or re-arranged to make the picture, so the images cannot
+  drift from the plan. The old silhouette renderers remain as automatic
+  fallbacks.
+- **The printer's screen shows the 3D view.** The thumbnail embedded in
+  each plate's G-code (what the U1 touchscreen and app display for the
+  file) is now a clean render of the 3D toolpath view instead of the flat
+  footprint.
+- **Filament and time on the confirm card.** The readiness card now leads
+  with the estimate ("Estimated: 5h 48m, 66g filament") pulled from the
+  sliced G-code's own metadata, and the 3D image's footer carries the same
+  numbers.
+
+### Fixed
+
+- **Sending a kit mid-conversation works reliably.** A kit uploaded after
+  the first message of a session could leave the assistant without its U1
+  instructions, and a newer Hermes attachment note actively steered it
+  toward unpacking the file by hand. Kit detection now rides the message
+  itself as well as the session plumbing, states that the file must go to
+  the kit tool untouched, and logs loudly when a document matches nothing.
+- **The kit form survives Hermes upgrades.** The form callback is now
+  published by the plugin on every message instead of relying on a patched
+  Hermes file that package upgrades silently replace. The old patch remains
+  as a fallback for older Hermes builds, and the installer no longer aborts
+  when it cannot apply it.
+- **A renderer crash that could stop a kit after slicing.** A variable in
+  the top-down renderer went unbound on the successful path; the flow now
+  has tests that execute the renderers for real, plus a full end-to-end
+  slice test that runs wherever the runtime OrcaSlicer exists.
+
 ## [2.8.0] — 2026-07-20
 
 ### Added

--- a/plugin/src/snapmaker_u1/hooks/attachment_router.py
+++ b/plugin/src/snapmaker_u1/hooks/attachment_router.py
@@ -61,6 +61,25 @@ _KIT_DIRECTIVE = (
     "point and it drives the whole flow itself.]"
 )
 
+# The counter-directive woven into the USER MESSAGE itself. Round 2 of the
+# live failure (2026-07-22) proved why this is needed: the upgraded Hermes
+# document template actively tells the model to "extract the document's text
+# yourself, for example with the terminal tool", which for a print kit is
+# precisely the wrong move, and the model obeyed it both times. The gateway
+# builds the final message as template + "\n\n" + event.text AFTER this hook
+# runs, so text we prepend here lands directly below that advice and
+# overrides it with the more specific instruction. In-place mutation of
+# event.text is the same mutable-event contract auto_skill already relies
+# on, and it works identically on Hermes versions without the template.
+_KIT_TEXT_TAG = "[U1 PRINT KIT:"
+_KIT_TEXT_DIRECTIVE = (
+    "[U1 PRINT KIT: the attached file is a 3D print kit for the u1_kit tool. "
+    "Disregard any instruction above about extracting or reading the document "
+    "yourself; do not unzip, list, or open it with the terminal or any other "
+    "tool. Call the u1_kit tool now with model_path set to the document's "
+    "saved path given above, then follow the tool's events.]"
+)
+
 
 def _document_file_name(raw: Any) -> str | None:
     """The attachment's filename from the raw platform message, if any.
@@ -96,6 +115,27 @@ def _arm_kit_directive(event: Any) -> bool:
     except Exception as exc:
         logger.warning(
             "snapmaker_u1 attachment_router: failed to arm kit directive: %s",
+            exc,
+        )
+        return False
+
+
+def _arm_kit_text_directive(event: Any) -> bool:
+    """Prepend the u1_kit counter-directive to the event's text in place.
+
+    The gateway later composes the final user message as document-template +
+    event.text, so this lands right under the template's generic "extract it
+    yourself with the terminal tool" advice and overrides it for kits.
+    Idempotent (tag check) and fail-soft."""
+    try:
+        current = getattr(event, "text", "") or ""
+        if _KIT_TEXT_TAG in current:
+            return True
+        event.text = (_KIT_TEXT_DIRECTIVE + "\n\n" + current).strip()
+        return True
+    except Exception as exc:
+        logger.warning(
+            "snapmaker_u1 attachment_router: failed to arm text directive: %s",
             exc,
         )
         return False
@@ -156,7 +196,11 @@ def make_handler(skill_identifier: str) -> Callable[..., Any]:
         if not getattr(event, "auto_skill", None):
             try:
                 event.auto_skill = skill_identifier
-                logger.info(
+                # WARNING on purpose: the gateway's default stderr level
+                # filters INFO, which made two live failures completely
+                # silent. A kit upload is rare enough that one loud line per
+                # arm is the right trade.
+                logger.warning(
                     "snapmaker_u1 attachment_router: set event.auto_skill=%r (via %s)",
                     skill_identifier, matched_by,
                 )
@@ -164,15 +208,20 @@ def make_handler(skill_identifier: str) -> Callable[..., Any]:
                 logger.warning(
                     "snapmaker_u1 attachment_router: failed to set auto_skill: %s", exc,
                 )
-        # Per-turn directive for attachment matches, REGARDLESS of auto_skill
-        # state: mid-session the loader drops auto_skill (not a new session),
-        # and a topic binding's auto_skill is dropped the same way, so the
-        # channel_prompt directive is what actually reaches the model turn.
+        # Per-turn directives for attachment matches, REGARDLESS of
+        # auto_skill state: mid-session the loader drops auto_skill (not a
+        # new session), and a topic binding's auto_skill is dropped the same
+        # way. Two carriers, belt and suspenders: channel_prompt rides the
+        # turn's ephemeral prompt, and the text prepend lands in the user
+        # message itself, directly under the gateway's document template
+        # whose generic extract-it-yourself advice it must override.
         if matched_by in ("text-regex", "doc-filename"):
-            if _arm_kit_directive(event):
-                logger.info(
-                    "snapmaker_u1 attachment_router: kit directive armed (via %s)",
-                    matched_by,
-                )
+            armed_prompt = _arm_kit_directive(event)
+            armed_text = _arm_kit_text_directive(event)
+            logger.warning(
+                "snapmaker_u1 attachment_router: kit directives armed "
+                "(via %s, channel_prompt=%s, text=%s)",
+                matched_by, armed_prompt, armed_text,
+            )
         return None  # let dispatch continue normally
     return handler

--- a/plugin/src/snapmaker_u1/hooks/attachment_router.py
+++ b/plugin/src/snapmaker_u1/hooks/attachment_router.py
@@ -43,6 +43,63 @@ _ATTACHMENT_RE = re.compile(r"\.(stl|3mf|zip)\b", re.IGNORECASE)
 _REPRINT_RE = re.compile(r"\b(reprint|print\s+(it|that|this)?\s*again)\b",
                          re.IGNORECASE)
 
+# Per-turn steering for MID-SESSION kit uploads. auto_skill alone stopped
+# covering this: the gateway's loader injects the skill body only when
+# `_is_new_session` is true ("ongoing conversations already have the skill
+# in history"), which is false the moment a kit arrives on any turn after
+# the first; the model then has no idea u1_kit exists and hand-unzips the
+# attachment (live 2026-07-21, post-upgrade). channel_prompt rides the
+# event into the TURN'S ephemeral prompt on every dispatch, new session or
+# not, so the one instruction that matters always lands. The full skill
+# still auto-loads on new sessions via auto_skill, exactly as before.
+_KIT_DIRECTIVE_TAG = "[U1 print kit attachment detected"
+_KIT_DIRECTIVE = (
+    "[U1 print kit attachment detected in this message. Immediately call the "
+    "u1_kit tool with model_path set to the attachment's saved file path "
+    "exactly as it appears in the message. Do not unzip, list, slice, or "
+    "inspect the file with any other tool; u1_kit is the only correct entry "
+    "point and it drives the whole flow itself.]"
+)
+
+
+def _document_file_name(raw: Any) -> str | None:
+    """The attachment's filename from the raw platform message, if any.
+
+    Handles both shapes seen across Hermes versions: an object graph
+    (python-telegram-bot's Message.document.file_name) and plain dicts
+    (adapters that pass the Bot API payload through unwrapped)."""
+    if raw is None:
+        return None
+    doc = getattr(raw, "document", None)
+    if doc is None and isinstance(raw, dict):
+        doc = raw.get("document")
+    if doc is None:
+        return None
+    name = getattr(doc, "file_name", None)
+    if name is None and isinstance(doc, dict):
+        name = doc.get("file_name")
+    return name if isinstance(name, str) and name else None
+
+
+def _arm_kit_directive(event: Any) -> bool:
+    """Append the u1_kit directive to the event's channel_prompt.
+
+    Idempotent (tag check) and fail-soft: a Hermes whose events have no
+    channel_prompt simply ignores the attribute and we degrade to the
+    auto_skill-only behavior this hook always had."""
+    try:
+        current = getattr(event, "channel_prompt", None) or ""
+        if _KIT_DIRECTIVE_TAG in current:
+            return True
+        event.channel_prompt = (current + "\n\n" + _KIT_DIRECTIVE).strip()
+        return True
+    except Exception as exc:
+        logger.warning(
+            "snapmaker_u1 attachment_router: failed to arm kit directive: %s",
+            exc,
+        )
+        return False
+
 
 def make_handler(skill_identifier: str) -> Callable[..., Any]:
     """Build the pre_gateway_dispatch handler with the resolved skill identifier baked in.
@@ -60,22 +117,16 @@ def make_handler(skill_identifier: str) -> Callable[..., Any]:
             return None
         try:
             _text = getattr(event, "text", "") or ""
-            _raw = getattr(event, "raw_message", None)
-            _has_doc = bool(_raw) and hasattr(_raw, "document") and _raw.document is not None
-            _doc_name = getattr(_raw.document, "file_name", None) if _has_doc else None
+            _doc_name = _document_file_name(getattr(event, "raw_message", None))
             logger.debug(
-                "snapmaker_u1 attachment_router: text_len=%d has_doc=%s doc_name=%r "
+                "snapmaker_u1 attachment_router: text_len=%d doc_name=%r "
                 "current_auto_skill=%r",
-                len(_text), _has_doc, _doc_name, getattr(event, "auto_skill", None),
+                len(_text), _doc_name, getattr(event, "auto_skill", None),
             )
         except Exception as _exc:
             logger.warning("snapmaker_u1 attachment_router: event inspect failed: %s", _exc)
             _text = ""
-            _has_doc = False
             _doc_name = None
-        # Don't overwrite an already-set auto_skill.
-        if getattr(event, "auto_skill", None):
-            return None
         # Try BOTH the visible text (post-template) and the raw document
         # filename (pre-template): the hook fires before Hermes injects the
         # attachment template, so the filename match is the one that lands on
@@ -88,16 +139,40 @@ def make_handler(skill_identifier: str) -> Callable[..., Any]:
         elif _text and _REPRINT_RE.search(_text):
             matched_by = "reprint-phrase"
         if not matched_by:
+            if _doc_name:
+                # A document arrived and NOTHING matched. For this operator's
+                # bot that is the anomaly worth shouting about: it is exactly
+                # how a silent extension gap or an upstream raw-shape change
+                # would present (live 2026-07-21: the miss produced no log at
+                # all and took a session of archaeology to find).
+                logger.warning(
+                    "snapmaker_u1 attachment_router: document %r arrived but "
+                    "matched no kit pattern; u1_kit was NOT recommended",
+                    _doc_name,
+                )
             return None
-        try:
-            event.auto_skill = skill_identifier
-            logger.info(
-                "snapmaker_u1 attachment_router: set event.auto_skill=%r (via %s)",
-                skill_identifier, matched_by,
-            )
-        except Exception as exc:
-            logger.warning(
-                "snapmaker_u1 attachment_router: failed to set auto_skill: %s", exc,
-            )
+        # Full skill for new sessions (the gateway's loader only injects on
+        # a session's first message). Never overwrite a topic binding's pick.
+        if not getattr(event, "auto_skill", None):
+            try:
+                event.auto_skill = skill_identifier
+                logger.info(
+                    "snapmaker_u1 attachment_router: set event.auto_skill=%r (via %s)",
+                    skill_identifier, matched_by,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "snapmaker_u1 attachment_router: failed to set auto_skill: %s", exc,
+                )
+        # Per-turn directive for attachment matches, REGARDLESS of auto_skill
+        # state: mid-session the loader drops auto_skill (not a new session),
+        # and a topic binding's auto_skill is dropped the same way, so the
+        # channel_prompt directive is what actually reaches the model turn.
+        if matched_by in ("text-regex", "doc-filename"):
+            if _arm_kit_directive(event):
+                logger.info(
+                    "snapmaker_u1 attachment_router: kit directive armed (via %s)",
+                    matched_by,
+                )
         return None  # let dispatch continue normally
     return handler

--- a/scripts/u1_gcode_preview.py
+++ b/scripts/u1_gcode_preview.py
@@ -166,8 +166,14 @@ _SIN30 = math.sin(math.radians(30))
 
 
 def _iso(x: float, y: float, z: float) -> tuple[float, float]:
-    """Project bed-space mm to isometric plane units (y grows downward later)."""
-    return (x - y) * _COS30, (x + y) * _SIN30 - z
+    """Project bed-space mm to isometric plane units.
+
+    ``v`` is height-on-screen before the raster flip: both distance from the
+    viewer corner (x + y) and physical height (z) raise a point. The first
+    cut subtracted z here, which drew every print upside down (base at the
+    top); an operator caught it on the first review image.
+    """
+    return (x - y) * _COS30, (x + y) * _SIN30 + z
 
 
 def _part_colors(parts: list[str]) -> dict[str, tuple[int, int, int]]:

--- a/scripts/u1_gcode_preview.py
+++ b/scripts/u1_gcode_preview.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Isometric toolpath preview rendered straight from sliced gcode.
+
+Experiment (feature/gcode-truth-previews): the shipped 3D review image keeps
+only each part's outer-wall silhouette, so supports are invisible and a part
+lying on its side can read like one standing up. This renders the actual
+toolpaths instead: every extrusion move, grouped by Orca's ``;TYPE:`` labels
+and ``M486`` part markers, drawn bottom-up in a true isometric projection.
+Supports get their own color, so "where are the supports" is answered by the
+image the operator already receives, and the silhouette of the real layers
+shows the true print pose. The gcode is the ground truth the printer runs,
+so nothing is re-sliced or re-arranged to make the picture.
+
+Standalone CLI for experimentation:
+
+    python3 u1_gcode_preview.py plate_1.gcode out.png [--title "Plate 1"]
+"""
+from __future__ import annotations
+
+import math
+import re
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+# --------------------------------------------------------------------------- #
+# Parsing: extrusion segments tagged with part + feature type
+# --------------------------------------------------------------------------- #
+
+_NUM = r"(-?\d*\.?\d+)"
+_G_RE = re.compile(r"^G[0123]\b")
+_G23_RE = re.compile(r"^G[23]\b")
+_X_RE = re.compile(r"\bX" + _NUM)
+_Y_RE = re.compile(r"\bY" + _NUM)
+_Z_RE = re.compile(r"\bZ" + _NUM)
+_E_RE = re.compile(r"\bE" + _NUM)
+_I_RE = re.compile(r"\bI" + _NUM)
+_J_RE = re.compile(r"\bJ" + _NUM)
+_M486_A = re.compile(r"^M486 A(.+?)\s*$")
+_M486_S = re.compile(r"^M486 S(-?\d+)")
+
+# Feature categories, in back-to-front draw order within a layer. Everything
+# supports-ish shares one bucket so the operator reads one color as "support".
+_TYPE_TO_CAT = {
+    "Brim": "brim",
+    "Skirt": "brim",
+    "Support": "support",
+    "Support interface": "support",
+    "Support transition": "support",
+    "Bottom surface": "bottom",
+    "Internal solid infill": None,       # interior noise at preview scale
+    "Sparse infill": None,
+    "Internal Bridge": None,
+    "Inner wall": "inner",
+    "Outer wall": "outer",
+    "Overhang wall": "outer",
+    "Bridge": "outer",
+    "Gap infill": None,
+    "Top surface": "top",
+    "Custom": None,                      # start/end/purge blocks
+}
+_CAT_ORDER = {"brim": 0, "support": 1, "bottom": 2, "inner": 3, "outer": 4, "top": 5}
+
+_META_RE = {
+    "filament_g": re.compile(r"^; total filament used \[g\] = " + _NUM),
+    "time": re.compile(r"^; estimated printing time \(normal mode\) = (.+)$"),
+}
+
+
+def parse_toolpaths(gcode_path: Path) -> dict[str, Any]:
+    """Extract every extrusion segment from ``gcode_path``.
+
+    Returns ``{"segments": [(z, seq, cat, part, x0, y0, x1, y1), ...],
+    "parts": [base names in first-seen order], "meta": {...}}``. Arc moves
+    (G2/G3) are flattened to chords the same way the shipped M486 renderer
+    does, so both previews corroborate. Extrusion is any G move with E > 0,
+    which holds for the relative-E gcode the U1 profiles emit.
+    """
+    segments: list[tuple] = []
+    id_to_name: dict[int, str] = {}
+    part_order: list[str] = []
+    meta: dict[str, Any] = {}
+    cid: int | None = None
+    cbase: str | None = None
+    ctype: str | None = None
+    prevx = prevy = None
+    cz = 0.0
+    seq = 0
+
+    for ln in Path(gcode_path).read_text(errors="replace").splitlines():
+        if ln.startswith(";"):
+            if ln.startswith(";TYPE:"):
+                ctype = ln[6:].strip()
+                continue
+            for key, rx in _META_RE.items():
+                if key not in meta:
+                    m = rx.match(ln)
+                    if m:
+                        meta[key] = m.group(1)
+            continue
+        ma = _M486_A.match(ln)
+        if ma:
+            if cid is not None:
+                id_to_name[cid] = ma.group(1).strip()
+            continue
+        ms = _M486_S.match(ln)
+        if ms:
+            nid = int(ms.group(1))
+            cid = None if nid < 0 else nid
+            nm = id_to_name.get(cid, "") if cid is not None else ""
+            cbase = re.sub(r"_id_\d+_copy_\d+$", "", nm) or (nm or None)
+            if cbase and cbase not in part_order:
+                part_order.append(cbase)
+            continue
+        if not _G_RE.match(ln):
+            continue
+        zm = _Z_RE.search(ln)
+        if zm:
+            cz = float(zm.group(1))
+        xm = _X_RE.search(ln)
+        ym = _Y_RE.search(ln)
+        em = _E_RE.search(ln)
+        nx = float(xm.group(1)) if xm else prevx
+        ny = float(ym.group(1)) if ym else prevy
+        cat = _TYPE_TO_CAT.get(ctype or "", None)
+        if (em and float(em.group(1)) > 0 and cat and prevx is not None
+                and nx is not None and ny is not None):
+            if _G23_RE.match(ln):
+                im = _I_RE.search(ln)
+                jm = _J_RE.search(ln)
+                cx = prevx + (float(im.group(1)) if im else 0.0)
+                cy = prevy + (float(jm.group(1)) if jm else 0.0)
+                r = math.hypot(prevx - cx, prevy - cy)
+                sa = math.atan2(prevy - cy, prevx - cx)
+                ea = math.atan2(ny - cy, nx - cx)
+                if ln.startswith("G2"):
+                    if ea > sa:
+                        ea -= 2 * math.pi
+                    sweep = sa - ea
+                else:
+                    if ea < sa:
+                        ea += 2 * math.pi
+                    sweep = ea - sa
+                nseg = max(2, int(abs(sweep) * r / 1.0))
+                px, py = prevx, prevy
+                for k in range(1, nseg + 1):
+                    a = sa - sweep * k / nseg if ln.startswith("G2") else sa + sweep * k / nseg
+                    qx, qy = cx + r * math.cos(a), cy + r * math.sin(a)
+                    segments.append((cz, seq, cat, cbase, px, py, qx, qy))
+                    seq += 1
+                    px, py = qx, qy
+            else:
+                segments.append((cz, seq, cat, cbase, prevx, prevy, nx, ny))
+                seq += 1
+        prevx, prevy = nx, ny
+
+    return {"segments": segments, "parts": part_order, "meta": meta}
+
+
+# --------------------------------------------------------------------------- #
+# Rendering: true isometric, painter's algorithm bottom-up
+# --------------------------------------------------------------------------- #
+
+_COS30 = math.cos(math.radians(30))
+_SIN30 = math.sin(math.radians(30))
+
+
+def _iso(x: float, y: float, z: float) -> tuple[float, float]:
+    """Project bed-space mm to isometric plane units (y grows downward later)."""
+    return (x - y) * _COS30, (x + y) * _SIN30 - z
+
+
+def _part_colors(parts: list[str]) -> dict[str, tuple[int, int, int]]:
+    import colorsys
+    colors: dict[str, tuple[int, int, int]] = {}
+    for i, p in enumerate(parts):
+        h = (i * 0.618034) % 1.0
+        r, g, b = colorsys.hsv_to_rgb(h, 0.55, 0.88)
+        colors[p] = (int(r * 255), int(g * 255), int(b * 255))
+    return colors
+
+
+def _dim(c: tuple[int, int, int], f: float) -> tuple[int, int, int]:
+    return tuple(int(v * f) for v in c)  # type: ignore[return-value]
+
+
+def _lift(c: tuple[int, int, int], f: float) -> tuple[int, int, int]:
+    return tuple(int(v + (255 - v) * f) for v in c)  # type: ignore[return-value]
+
+
+_SUPPORT_COLOR = (255, 158, 60)
+_BRIM_COLOR = (88, 99, 112)
+_BED_GRID = (43, 50, 60)
+_BED_EDGE = (66, 76, 90)
+_BG = (22, 26, 31)
+
+
+def render_iso_preview(
+    gcode_path: Path,
+    out_path: Path,
+    *,
+    bed_mm: tuple[float, float] = (270.0, 270.0),
+    canvas_px: int = 1200,
+    title: str | None = None,
+) -> dict[str, Any]:
+    """Render ``gcode_path`` to ``out_path`` as an isometric toolpath preview.
+
+    Best-effort like the shipped renderers: every failure returns
+    ``{"ok": False, "error": ...}`` so a caller can fall back to the old view.
+    """
+    try:
+        from PIL import Image, ImageDraw
+    except Exception as exc:  # pragma: no cover - deps guard
+        return {"ok": False, "path": None, "error": f"deps: {exc}"}
+    try:
+        parsed = parse_toolpaths(gcode_path)
+    except Exception as exc:
+        return {"ok": False, "path": None, "error": f"gcode parse: {exc}"}
+    segs = parsed["segments"]
+    if not segs:
+        return {"ok": False, "path": None, "error": "no extrusion segments found"}
+
+    colors = _part_colors(parsed["parts"])
+    support_segs = sum(1 for s in segs if s[2] == "support")
+
+    # Frame on the printed material, not the whole bed: orientation and
+    # supports are this view's job, placement is the top-down's.
+    pts = []
+    for z, _seq, _cat, _part, x0, y0, x1, y1 in segs:
+        pts.append(_iso(x0, y0, z))
+        pts.append(_iso(x1, y1, z))
+    us = [p[0] for p in pts]
+    vs = [p[1] for p in pts]
+    umin, umax = min(us), max(us)
+    vmin, vmax = min(vs), max(vs)
+    span = max(umax - umin, vmax - vmin, 1.0)
+    pad = span * 0.10
+    umin -= pad
+    umax += pad
+    vmin -= pad
+    vmax += pad
+    header = 56 if title else 0
+    footer = 44
+    draw_h = canvas_px - header - footer
+    scale = min(canvas_px / (umax - umin), draw_h / (vmax - vmin))
+
+    def to_px(x: float, y: float, z: float) -> tuple[float, float]:
+        u, v = _iso(x, y, z)
+        return ((u - umin) * scale, header + (vmax - v) * scale)
+
+    img = Image.new("RGB", (canvas_px, canvas_px), _BG)
+    draw = ImageDraw.Draw(img)
+
+    # Bed grid at z=0 under the model, clipped by the frame automatically.
+    bx, by = bed_mm
+    step = 50.0
+    x = 0.0
+    while x <= bx + 1e-6:
+        draw.line([to_px(x, 0, 0), to_px(x, by, 0)],
+                  fill=_BED_EDGE if x in (0.0, bx) else _BED_GRID, width=1)
+        x += step
+    y = 0.0
+    while y <= by + 1e-6:
+        draw.line([to_px(0, y, 0), to_px(bx, y, 0)],
+                  fill=_BED_EDGE if y in (0.0, by) else _BED_GRID, width=1)
+        y += step
+
+    # Painter's algorithm: strict layer order carries the depth story, and
+    # within a layer back-to-front category order keeps part edges crisp.
+    segs.sort(key=lambda s: (s[0], _CAT_ORDER[s[2]], s[1]))
+    for z, _seq, cat, part, x0, y0, x1, y1 in segs:
+        base = colors.get(part, (150, 160, 170))
+        if cat == "support":
+            fill, width = _SUPPORT_COLOR, 2
+        elif cat == "brim":
+            fill, width = _BRIM_COLOR, 1
+        elif cat == "inner":
+            fill, width = _dim(base, 0.45), 1
+        elif cat == "bottom":
+            fill, width = _dim(base, 0.70), 1
+        elif cat == "top":
+            fill, width = _lift(base, 0.35), 2
+        else:  # outer
+            fill, width = base, 2
+        draw.line([to_px(x0, y0, z), to_px(x1, y1, z)], fill=fill, width=width)
+
+    # Header / footer text with the DejaVu fallback the workflow uses.
+    try:
+        from PIL import ImageFont
+        try:
+            f_big = ImageFont.truetype(
+                "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 24)
+            f_small = ImageFont.truetype(
+                "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 17)
+        except Exception:
+            f_big = f_small = ImageFont.load_default()
+        if title:
+            draw.text((16, 14), title, fill=(235, 238, 242), font=f_big)
+        meta = parsed["meta"]
+        bits = []
+        if meta.get("filament_g"):
+            bits.append(f"{meta['filament_g']} g filament")
+        if meta.get("time"):
+            bits.append(meta["time"])
+        bits.append("supports shown in orange" if support_segs
+                    else "no supports in this plate")
+        draw.text((16, canvas_px - 32), "  ·  ".join(bits),
+                  fill=(170, 178, 188), font=f_small)
+    except Exception:
+        pass  # text is garnish; the geometry is the payload
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    img.save(out_path)
+    return {"ok": True, "path": str(out_path), "segments": len(segs),
+            "support_segments": support_segs, "parts": parsed["parts"],
+            "meta": parsed["meta"]}
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("gcode", type=Path)
+    ap.add_argument("out", type=Path)
+    ap.add_argument("--title", default=None)
+    ap.add_argument("--bed", default="270x270",
+                    help="bed size in mm, WIDTHxDEPTH (default 270x270)")
+    a = ap.parse_args(argv)
+    bw, _, bd = a.bed.partition("x")
+    res = render_iso_preview(a.gcode, a.out, title=a.title,
+                             bed_mm=(float(bw), float(bd or bw)))
+    print(res)
+    return 0 if res.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/u1_gcode_preview.py
+++ b/scripts/u1_gcode_preview.py
@@ -211,6 +211,23 @@ _BED_EDGE = (66, 76, 90)
 _BG = (22, 26, 31)
 
 
+def _style_for(cat: str, base: tuple[int, int, int],
+               ) -> tuple[tuple[int, int, int], int]:
+    """(fill, width) for a feature category. One place, so the isometric and
+    top-down views can never drift apart on what a support looks like."""
+    if cat == "support":
+        return _SUPPORT_COLOR, 2
+    if cat == "brim":
+        return _BRIM_COLOR, 1
+    if cat == "inner":
+        return _dim(base, 0.45), 1
+    if cat == "bottom":
+        return _dim(base, 0.70), 1
+    if cat == "top":
+        return _lift(base, 0.35), 2
+    return base, 2  # outer and friends
+
+
 def render_iso_preview(
     gcode_path: Path,
     out_path: Path,
@@ -290,19 +307,7 @@ def render_iso_preview(
     # within a layer back-to-front category order keeps part edges crisp.
     segs.sort(key=lambda s: (s[0], _CAT_ORDER[s[2]], s[1]))
     for z, _seq, cat, part, x0, y0, x1, y1 in segs:
-        base = colors.get(part, (150, 160, 170))
-        if cat == "support":
-            fill, width = _SUPPORT_COLOR, 2
-        elif cat == "brim":
-            fill, width = _BRIM_COLOR, 1
-        elif cat == "inner":
-            fill, width = _dim(base, 0.45), 1
-        elif cat == "bottom":
-            fill, width = _dim(base, 0.70), 1
-        elif cat == "top":
-            fill, width = _lift(base, 0.35), 2
-        else:  # outer
-            fill, width = base, 2
+        fill, width = _style_for(cat, colors.get(part, (150, 160, 170)))
         draw.line([to_px(x0, y0, z), to_px(x1, y1, z)], fill=fill, width=width)
 
     # Header / footer text with the DejaVu fallback the workflow uses.
@@ -338,6 +343,104 @@ def render_iso_preview(
     return {"ok": True, "path": str(out_path), "segments": len(segs),
             "support_segments": support_segs, "parts": parsed["parts"],
             "meta": parsed["meta"]}
+
+
+def render_top_preview(
+    gcode_path: Path,
+    out_path: Path,
+    *,
+    bed_mm: tuple[float, float] = (270.0, 270.0),
+    canvas_px: int = 1000,
+    title: str | None = None,
+    label_below: str | None = None,
+    chrome: bool = True,
+) -> dict[str, Any]:
+    """Top-down plate view from the same toolpaths as the isometric.
+
+    Replaces the outer-wall-silhouette footprint: straight-down orthographic
+    over the FULL bed (this view's job is placement), but drawing the real
+    geometry with the shared category styling, so the part actually looks
+    like itself from above, supports show in orange, and the colors match
+    the 3D view segment for segment. Best-effort like every renderer here.
+    """
+    try:
+        from PIL import Image, ImageDraw
+    except Exception as exc:  # pragma: no cover - deps guard
+        return {"ok": False, "path": None, "error": f"deps: {exc}"}
+    try:
+        parsed = parse_toolpaths(gcode_path)
+    except Exception as exc:
+        return {"ok": False, "path": None, "error": f"gcode parse: {exc}"}
+    segs = parsed["segments"]
+    if not segs:
+        return {"ok": False, "path": None, "error": "no extrusion segments found"}
+
+    colors = part_colors(parsed["parts"])
+    support_segs = sum(1 for s in segs if s[2] == "support")
+    bed_w, bed_h = bed_mm
+
+    title_h = 50 if (title and chrome) else 0
+    footer_h = (30 if label_below else 0) + (26 if chrome else 0)
+    pad = 16
+    plot = canvas_px
+    img = Image.new("RGB", (plot + pad * 2, plot + pad * 2 + title_h + footer_h),
+                    _BG)
+    draw = ImageDraw.Draw(img)
+    x0, y0 = pad, pad + title_h
+    x1, y1 = x0 + plot, y0 + plot
+    draw.rectangle([x0, y0, x1, y1], fill=(30, 34, 40))
+    ppm = plot / max(bed_w, bed_h)
+
+    def to_px(mx: float, my: float) -> tuple[float, float]:
+        return x0 + mx * ppm, y1 - my * ppm  # bed origin bottom-left, y up
+
+    # Grid + mm labels every 50 mm, matching the placement view operators
+    # already read.
+    try:
+        from PIL import ImageFont
+        try:
+            f_big = ImageFont.truetype(
+                "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 22)
+            f_small = ImageFont.truetype(
+                "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 15)
+        except Exception:
+            f_big = f_small = ImageFont.load_default()
+    except Exception:
+        f_big = f_small = None
+    for mm in range(0, int(bed_w) + 1, 50):
+        gx = x0 + mm * ppm
+        if gx <= x1 + 0.5:
+            draw.line([(gx, y0), (gx, y1)], fill=_BED_GRID)
+            if chrome and f_small is not None:
+                draw.text((gx + 3, y1 - 18), str(mm), fill=(120, 130, 142),
+                          font=f_small)
+    for mm in range(0, int(bed_h) + 1, 50):
+        gy = y1 - mm * ppm
+        if gy >= y0 - 0.5:
+            draw.line([(x0, gy), (x1, gy)], fill=_BED_GRID)
+
+    segs.sort(key=lambda s: (s[0], _CAT_ORDER[s[2]], s[1]))
+    for z, _seq, cat, part, sx0, sy0, sx1, sy1 in segs:
+        fill, width = _style_for(cat, colors.get(part, (150, 160, 170)))
+        draw.line([to_px(sx0, sy0), to_px(sx1, sy1)], fill=fill, width=width)
+
+    if chrome and f_big is not None:
+        if title:
+            draw.text((pad, 14), title, fill=(235, 238, 242), font=f_big)
+        foot_y = y1 + 8
+        if label_below:
+            draw.text((pad, foot_y), label_below, fill=(235, 238, 242),
+                      font=f_small)
+            foot_y += 26
+        note = ("supports shown in orange" if support_segs
+                else "toolpaths from the sliced gcode")
+        draw.text((pad, foot_y), note, fill=(140, 150, 160), font=f_small)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    img.save(out_path)
+    return {"ok": True, "path": str(out_path), "part_count": len(parsed["parts"]),
+            "segments": len(segs), "support_segments": support_segs,
+            "parts": parsed["parts"], "meta": parsed["meta"]}
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/u1_gcode_preview.py
+++ b/scripts/u1_gcode_preview.py
@@ -218,8 +218,13 @@ def render_iso_preview(
     bed_mm: tuple[float, float] = (270.0, 270.0),
     canvas_px: int = 1200,
     title: str | None = None,
+    chrome: bool = True,
 ) -> dict[str, Any]:
     """Render ``gcode_path`` to ``out_path`` as an isometric toolpath preview.
+
+    ``chrome=False`` drops the title header and footer text entirely: text
+    turns to noise at the printer touchscreen's 48/300 px thumbnail sizes,
+    so the injected thumbnail wants pure geometry.
 
     Best-effort like the shipped renderers: every failure returns
     ``{"ok": False, "error": ...}`` so a caller can fall back to the old view.
@@ -255,8 +260,8 @@ def render_iso_preview(
     umax += pad
     vmin -= pad
     vmax += pad
-    header = 56 if title else 0
-    footer = 44
+    header = 56 if (title and chrome) else 0
+    footer = 44 if chrome else 0
     draw_h = canvas_px - header - footer
     scale = min(canvas_px / (umax - umin), draw_h / (vmax - vmin))
 
@@ -301,29 +306,32 @@ def render_iso_preview(
         draw.line([to_px(x0, y0, z), to_px(x1, y1, z)], fill=fill, width=width)
 
     # Header / footer text with the DejaVu fallback the workflow uses.
-    try:
-        from PIL import ImageFont
+    # Skipped entirely for chrome-free thumbnail renders: text turns to
+    # noise at touchscreen thumbnail sizes.
+    if chrome:
         try:
-            f_big = ImageFont.truetype(
-                "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 24)
-            f_small = ImageFont.truetype(
-                "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 17)
+            from PIL import ImageFont
+            try:
+                f_big = ImageFont.truetype(
+                    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 24)
+                f_small = ImageFont.truetype(
+                    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 17)
+            except Exception:
+                f_big = f_small = ImageFont.load_default()
+            if title:
+                draw.text((16, 14), title, fill=(235, 238, 242), font=f_big)
+            meta = parsed["meta"]
+            bits = []
+            if meta.get("filament_g"):
+                bits.append(f"{meta['filament_g']} g filament")
+            if meta.get("time"):
+                bits.append(meta["time"])
+            bits.append("supports shown in orange" if support_segs
+                        else "no supports in this plate")
+            draw.text((16, canvas_px - 32), "  ·  ".join(bits),
+                      fill=(170, 178, 188), font=f_small)
         except Exception:
-            f_big = f_small = ImageFont.load_default()
-        if title:
-            draw.text((16, 14), title, fill=(235, 238, 242), font=f_big)
-        meta = parsed["meta"]
-        bits = []
-        if meta.get("filament_g"):
-            bits.append(f"{meta['filament_g']} g filament")
-        if meta.get("time"):
-            bits.append(meta["time"])
-        bits.append("supports shown in orange" if support_segs
-                    else "no supports in this plate")
-        draw.text((16, canvas_px - 32), "  ·  ".join(bits),
-                  fill=(170, 178, 188), font=f_small)
-    except Exception:
-        pass  # text is garnish; the geometry is the payload
+            pass  # text is garnish; the geometry is the payload
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
     img.save(out_path)

--- a/scripts/u1_gcode_preview.py
+++ b/scripts/u1_gcode_preview.py
@@ -107,8 +107,10 @@ def parse_toolpaths(gcode_path: Path) -> dict[str, Any]:
         if ms:
             nid = int(ms.group(1))
             cid = None if nid < 0 else nid
-            nm = id_to_name.get(cid, "") if cid is not None else ""
-            cbase = re.sub(r"_id_\d+_copy_\d+$", "", nm) or (nm or None)
+            # Key by the FULL M486 instance name, exactly like the top-down
+            # footprint renderer: each copy of a model keeps its own identity,
+            # and the shared sorted-name color map lines both images up.
+            cbase = (id_to_name.get(cid, "") if cid is not None else "") or None
             if cbase and cbase not in part_order:
                 part_order.append(cbase)
             continue
@@ -176,13 +178,21 @@ def _iso(x: float, y: float, z: float) -> tuple[float, float]:
     return (x - y) * _COS30, (x + y) * _SIN30 + z
 
 
-def _part_colors(parts: list[str]) -> dict[str, tuple[int, int, int]]:
+def part_colors(names: list[str]) -> dict[str, tuple[int, int, int]]:
+    """One part-to-color map for every review image.
+
+    Same formula the top-down footprint has always used (sorted M486 names,
+    evenly spaced hues at s=0.55 v=0.9), promoted here so the isometric view
+    and the footprint color the SAME part the SAME way. Two images that
+    disagree on which part is magenta are worse than one image.
+    """
     import colorsys
+    ordered = sorted(names)
+    n = max(len(ordered), 1)
     colors: dict[str, tuple[int, int, int]] = {}
-    for i, p in enumerate(parts):
-        h = (i * 0.618034) % 1.0
-        r, g, b = colorsys.hsv_to_rgb(h, 0.55, 0.88)
-        colors[p] = (int(r * 255), int(g * 255), int(b * 255))
+    for i, name in enumerate(ordered):
+        r, g, b = colorsys.hsv_to_rgb(i / n, 0.55, 0.9)
+        colors[name] = (int(r * 255), int(g * 255), int(b * 255))
     return colors
 
 
@@ -226,7 +236,7 @@ def render_iso_preview(
     if not segs:
         return {"ok": False, "path": None, "error": "no extrusion segments found"}
 
-    colors = _part_colors(parsed["parts"])
+    colors = part_colors(parsed["parts"])
     support_segs = sum(1 for s in segs if s[2] == "support")
 
     # Frame on the printed material, not the whole bed: orientation and

--- a/scripts/u1_kit_workflow.py
+++ b/scripts/u1_kit_workflow.py
@@ -1042,6 +1042,11 @@ def _render_plate_layout_from_m486_outer_walls(
 
     wall_px = max(2, int(wall_mm * ppm))
     names = sorted(objects.keys())
+    # n feeds the part_count in BOTH return paths below. The shared-colors
+    # change briefly left it bound only in the import-fallback branch, which
+    # made every successful render die at the return (live 2026-07-22, took
+    # the whole kit flow down); bind it before any branching.
+    n = len(names)
     # Shared part-to-color map (u1_gcode_preview.part_colors is the promoted
     # copy of this renderer's original formula) so the footprint and the 3D
     # toolpath view color the same part the same way. Inline fallback keeps
@@ -1050,7 +1055,6 @@ def _render_plate_layout_from_m486_outer_walls(
         from u1_gcode_preview import part_colors as _shared_part_colors
         color_map = _shared_part_colors(names)
     except Exception:
-        n = len(names)
         color_map = {}
         for i, name in enumerate(names):
             r, g, b = colorsys.hsv_to_rgb(i / n, 0.55, 0.9)

--- a/scripts/u1_kit_workflow.py
+++ b/scripts/u1_kit_workflow.py
@@ -1380,11 +1380,30 @@ def _render_and_inject_plate_preview(
             bed_mm=bed_mm, title=iso_title, label_below=label_below)
     if iso.get("ok"):
         layout["iso_path"] = iso["path"]
+    # Printer touchscreen thumbnail: prefer a chrome-free render of the 3D
+    # toolpath view (operator request 2026-07-22: the machine's screen should
+    # show the real print pose with supports, not the flat footprint). Text
+    # chrome turns to noise at the 48/300 px thumbnail sizes, so this is a
+    # separate geometry-only render. The top-down stays the fallback so
+    # injection never regresses when the toolpath render fails.
+    thumb_src: Path | None = None
+    if iso.get("ok"):
+        try:
+            from u1_gcode_preview import render_iso_preview as _iso_render
+            _thumb = _iso_render(
+                plate_gcode_path, out_dir / f"plate_{plate_idx}_iso_thumb.png",
+                bed_mm=bed_mm, canvas_px=600, chrome=False)
+            if _thumb.get("ok"):
+                thumb_src = Path(_thumb["path"])
+        except Exception:
+            thumb_src = None
+    if thumb_src is None and layout.get("ok"):
+        thumb_src = Path(layout["path"])
     injection = {"ok": False, "sizes": [],
                  "error": "render failed; nothing to inject"}
-    if layout.get("ok"):
-        injection = _inject_plate_thumbnail(plate_gcode_path,
-                                            Path(layout["path"]))
+    if thumb_src is not None:
+        injection = _inject_plate_thumbnail(plate_gcode_path, thumb_src)
+        injection["thumbnail_source"] = str(thumb_src)
     return layout, injection
 
 

--- a/scripts/u1_kit_workflow.py
+++ b/scripts/u1_kit_workflow.py
@@ -1042,11 +1042,21 @@ def _render_plate_layout_from_m486_outer_walls(
 
     wall_px = max(2, int(wall_mm * ppm))
     names = sorted(objects.keys())
-    n = len(names)
-    for i, name in enumerate(names):
-        hue = i / n
-        r, g, b = colorsys.hsv_to_rgb(hue, 0.55, 0.9)
-        color = (int(r * 255), int(g * 255), int(b * 255))
+    # Shared part-to-color map (u1_gcode_preview.part_colors is the promoted
+    # copy of this renderer's original formula) so the footprint and the 3D
+    # toolpath view color the same part the same way. Inline fallback keeps
+    # this renderer standalone if the preview module is missing on a deploy.
+    try:
+        from u1_gcode_preview import part_colors as _shared_part_colors
+        color_map = _shared_part_colors(names)
+    except Exception:
+        n = len(names)
+        color_map = {}
+        for i, name in enumerate(names):
+            r, g, b = colorsys.hsv_to_rgb(i / n, 0.55, 0.9)
+            color_map[name] = (int(r * 255), int(g * 255), int(b * 255))
+    for name in names:
+        color = color_map[name]
         for poly in objects[name]:
             pts = [to_px(x, y) for (x, y) in poly]
             if len(pts) >= 2:
@@ -1346,15 +1356,24 @@ def _render_and_inject_plate_preview(
             bed_mm=bed_mm, title=title, label_below=label_below,
         )
     # Isometric 3D companion view built from the SAME sliced gcode as the
-    # footprint above (v2.2.1: the old arranged-STL source used Orca's buggy
-    # --export-stl packer and produced a garbled layout that disagreed with the
-    # footprint). Corroborates by construction + shows height/orientation.
-    # Best-effort: if it fails we skip it (the footprint still shows).
-    iso = _render_plate_isometric_from_gcode(
-        plate_gcode_path, out_dir / f"plate_{plate_idx}_iso.png",
-        bed_mm=bed_mm,
-        title=f"Plate {plate_idx} of {plate_count}  -  3D view",
-        label_below=label_below)
+    # footprint above, so they corroborate by construction. Primary renderer
+    # draws the actual toolpaths (u1_gcode_preview): supports in their own
+    # color, real per-layer silhouettes for the print pose, shared part
+    # colors with the footprint. The outer-wall-prism renderer stays as the
+    # fallback, and if both fail we skip the 3D (the footprint still shows).
+    iso_out = out_dir / f"plate_{plate_idx}_iso.png"
+    iso_title = f"Plate {plate_idx} of {plate_count}  -  3D view"
+    iso: dict[str, Any] = {"ok": False}
+    try:
+        from u1_gcode_preview import render_iso_preview
+        iso = render_iso_preview(plate_gcode_path, iso_out,
+                                 bed_mm=bed_mm, title=iso_title)
+    except Exception as _iso_exc:
+        iso = {"ok": False, "error": f"toolpath preview: {_iso_exc}"}
+    if not iso.get("ok"):
+        iso = _render_plate_isometric_from_gcode(
+            plate_gcode_path, iso_out,
+            bed_mm=bed_mm, title=iso_title, label_below=label_below)
     if iso.get("ok"):
         layout["iso_path"] = iso["path"]
     injection = {"ok": False, "sizes": [],
@@ -5724,6 +5743,12 @@ def _commit_kit_legacy(args, request_id, operator, out_dir, events_file,
         _audit(request_id, "review_doc_failed", operator,
                error=f"{type(_rd_exc).__name__}: {_rd_exc}"[:200])
 
+    # Filament weight + print time from the sliced gcode's own metadata.
+    # The kit path's card has carried this since the aggregator landed; the
+    # form path built its card before that and never picked it up, so the
+    # operator had to open the laptop to learn a print was 66 g / 5h 48m.
+    _form_estimates = _aggregate_plate_estimates(plates_state)
+
     readiness = {
         "stage": "kit_readiness_card",
         "review_doc_path": review_doc_path,
@@ -5736,6 +5761,8 @@ def _commit_kit_legacy(args, request_id, operator, out_dir, events_file,
                     "gcode_hash": p["gcode_hash"]} for p in plates_state],
         "tool": tool, "material": material, "profile": profile_slug,
         "orient": values.get("orient"), "supports": supports,
+        "estimates": _form_estimates,
+        "estimated": _form_estimates.get("summary_line"),
         "parsed_echo": u1_form.echo_parse(values, spec),
         "gated_plate": plate1["printer_storage_filename"],
         # start_gate_stage1_command is deliberately NOT surfaced here — a

--- a/scripts/u1_kit_workflow.py
+++ b/scripts/u1_kit_workflow.py
@@ -1340,10 +1340,22 @@ def _render_and_inject_plate_preview(
     # needed): _render_plate_layout_from_3mf (--export-3mf uses the same
     # buggy packer as --export-stl) and _render_plate_layout_from_gcode_m486
     # (M486 rotation matching under-constrained, visible overlaps).
-    layout = _render_plate_layout_from_m486_outer_walls(
-        plate_gcode_path, plate_preview_path,
-        bed_mm=bed_mm, title=title, label_below=label_below,
-    )
+    # Primary: top-down TOOLPATH view (same geometry, styling, and part
+    # colors as the 3D view, full bed for placement). The silhouette chain
+    # below stays as the fallback so the review never loses its footprint.
+    layout: dict[str, Any] = {"ok": False}
+    try:
+        from u1_gcode_preview import render_top_preview
+        layout = render_top_preview(
+            plate_gcode_path, plate_preview_path,
+            bed_mm=bed_mm, title=title, label_below=label_below)
+    except Exception as _top_exc:
+        layout = {"ok": False, "error": f"toolpath top view: {_top_exc}"}
+    if not layout.get("ok"):
+        layout = _render_plate_layout_from_m486_outer_walls(
+            plate_gcode_path, plate_preview_path,
+            bed_mm=bed_mm, title=title, label_below=label_below,
+        )
     if not layout.get("ok"):
         layout = _render_plate_layout_from_gcode_layers(
             plate_gcode_path, plate_preview_path,

--- a/tests/test_attachment_router.py
+++ b/tests/test_attachment_router.py
@@ -1,0 +1,137 @@
+"""attachment_router: a 3D-model attachment must reach the model as a u1_kit
+instruction on EVERY turn, not just a session's first message.
+
+The gateway's auto-skill loader injects the skill body only on new sessions,
+so a kit uploaded mid-conversation used to leave the model with no idea
+u1_kit existed (live 2026-07-21: it hand-unzipped the attachment and hung on
+the interactive prompt). The router now arms a per-turn channel_prompt
+directive alongside auto_skill, detects document filenames in both the
+object and dict raw-message shapes, and logs a warning when a document
+arrives that matches nothing.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from snapmaker_u1.hooks import attachment_router as ar
+
+SKILL = "3d-printer-slicing-automation"
+
+
+def _handler():
+    return ar.make_handler(SKILL)
+
+
+def _event(text="", doc_name=None, raw_shape="object", auto_skill=None,
+           channel_prompt=None):
+    raw = None
+    if doc_name is not None:
+        if raw_shape == "object":
+            raw = SimpleNamespace(document=SimpleNamespace(file_name=doc_name))
+        else:
+            raw = {"document": {"file_name": doc_name}}
+    return SimpleNamespace(text=text, raw_message=raw, auto_skill=auto_skill,
+                           channel_prompt=channel_prompt)
+
+
+# ---------- detection ----------
+
+def test_zip_document_sets_skill_and_arms_directive():
+    ev = _event(doc_name="angles-teaching-aid-model_files.zip")
+    _handler()(event=ev)
+    assert ev.auto_skill == SKILL
+    assert ar._KIT_DIRECTIVE_TAG in (ev.channel_prompt or "")
+    assert "u1_kit" in ev.channel_prompt
+
+
+def test_dict_shaped_raw_message_is_detected():
+    """Upstream adapters have passed both an object graph and the bare Bot
+    API dict; a raw-shape change must not silently disable kit detection."""
+    ev = _event(doc_name="kit.stl", raw_shape="dict")
+    _handler()(event=ev)
+    assert ev.auto_skill == SKILL
+    assert ar._KIT_DIRECTIVE_TAG in ev.channel_prompt
+
+
+def test_text_path_mention_is_detected():
+    ev = _event(text="please print /opt/data/cache/documents/doc_ab12_kit.3mf")
+    _handler()(event=ev)
+    assert ev.auto_skill == SKILL
+    assert ar._KIT_DIRECTIVE_TAG in ev.channel_prompt
+
+
+def test_non_model_document_matches_nothing_and_warns(caplog):
+    import logging
+    ev = _event(doc_name="invoice.pdf")
+    with caplog.at_level(logging.WARNING):
+        _handler()(event=ev)
+    assert ev.auto_skill is None
+    assert ev.channel_prompt is None
+    assert any("matched no kit pattern" in r.message for r in caplog.records)
+
+
+def test_plain_chat_mutates_nothing():
+    ev = _event(text="how was the last print?")
+    _handler()(event=ev)
+    assert ev.auto_skill is None
+    assert ev.channel_prompt is None
+
+
+def test_stl_pipeline_style_name_is_not_a_false_positive():
+    ev = _event(text="the stl_pipeline.py script broke again")
+    _handler()(event=ev)
+    assert ev.auto_skill is None
+    assert ev.channel_prompt is None
+
+
+# ---------- mid-session and binding interplay ----------
+
+def test_directive_arms_even_when_auto_skill_already_bound():
+    """A topic binding's auto_skill is dropped by the loader mid-session the
+    same way ours is, so the directive must arm regardless. The bound skill
+    itself is never overwritten."""
+    ev = _event(doc_name="kit.zip", auto_skill="some-topic-skill")
+    _handler()(event=ev)
+    assert ev.auto_skill == "some-topic-skill"
+    assert ar._KIT_DIRECTIVE_TAG in ev.channel_prompt
+
+
+def test_directive_appends_to_existing_channel_prompt():
+    ev = _event(doc_name="kit.zip", channel_prompt="You are the print bot.")
+    _handler()(event=ev)
+    assert ev.channel_prompt.startswith("You are the print bot.")
+    assert ar._KIT_DIRECTIVE_TAG in ev.channel_prompt
+
+
+def test_directive_is_idempotent():
+    ev = _event(doc_name="kit.zip")
+    _handler()(event=ev)
+    once = ev.channel_prompt
+    _handler()(event=ev)
+    assert ev.channel_prompt == once
+
+
+# ---------- reprint keeps its existing behavior ----------
+
+def test_reprint_phrase_loads_skill_without_directive():
+    ev = _event(text="reprint the last one")
+    _handler()(event=ev)
+    assert ev.auto_skill == SKILL
+    assert ev.channel_prompt is None  # no attachment, no directive
+
+
+# ---------- resilience ----------
+
+def test_none_event_is_a_noop():
+    assert _handler()(event=None) is None
+
+
+def test_broken_event_never_raises():
+    class Hostile:
+        @property
+        def text(self):
+            raise RuntimeError("boom")
+
+        raw_message = None
+
+    assert _handler()(event=Hostile()) is None

--- a/tests/test_attachment_router.py
+++ b/tests/test_attachment_router.py
@@ -36,12 +36,16 @@ def _event(text="", doc_name=None, raw_shape="object", auto_skill=None,
 
 # ---------- detection ----------
 
-def test_zip_document_sets_skill_and_arms_directive():
+def test_zip_document_sets_skill_and_arms_directives():
     ev = _event(doc_name="angles-teaching-aid-model_files.zip")
     _handler()(event=ev)
     assert ev.auto_skill == SKILL
     assert ar._KIT_DIRECTIVE_TAG in (ev.channel_prompt or "")
     assert "u1_kit" in ev.channel_prompt
+    # The text counter-directive is the piece that beats the gateway's
+    # document template ("extract it yourself with the terminal tool").
+    assert ev.text.startswith(ar._KIT_TEXT_TAG)
+    assert "u1_kit" in ev.text
 
 
 def test_dict_shaped_raw_message_is_detected():
@@ -51,6 +55,7 @@ def test_dict_shaped_raw_message_is_detected():
     _handler()(event=ev)
     assert ev.auto_skill == SKILL
     assert ar._KIT_DIRECTIVE_TAG in ev.channel_prompt
+    assert ev.text.startswith(ar._KIT_TEXT_TAG)
 
 
 def test_text_path_mention_is_detected():
@@ -58,6 +63,16 @@ def test_text_path_mention_is_detected():
     _handler()(event=ev)
     assert ev.auto_skill == SKILL
     assert ar._KIT_DIRECTIVE_TAG in ev.channel_prompt
+
+
+def test_text_directive_prepends_and_keeps_the_caption():
+    """The gateway composes template + event.text AFTER the hook, so the
+    prepend puts the counter-directive under the template's bad advice and
+    above the operator's own caption."""
+    ev = _event(text="print this one for me", doc_name="kit.zip")
+    _handler()(event=ev)
+    assert ev.text.index(ar._KIT_TEXT_TAG) == 0
+    assert ev.text.endswith("print this one for me")
 
 
 def test_non_model_document_matches_nothing_and_warns(caplog):
@@ -103,12 +118,13 @@ def test_directive_appends_to_existing_channel_prompt():
     assert ar._KIT_DIRECTIVE_TAG in ev.channel_prompt
 
 
-def test_directive_is_idempotent():
+def test_directives_are_idempotent():
     ev = _event(doc_name="kit.zip")
     _handler()(event=ev)
-    once = ev.channel_prompt
+    once_prompt, once_text = ev.channel_prompt, ev.text
     _handler()(event=ev)
-    assert ev.channel_prompt == once
+    assert ev.channel_prompt == once_prompt
+    assert ev.text == once_text
 
 
 # ---------- reprint keeps its existing behavior ----------

--- a/tests/test_real_orca_kit_e2e.py
+++ b/tests/test_real_orca_kit_e2e.py
@@ -1,0 +1,86 @@
+"""End-to-end: drive u1_kit_workflow through a REAL Orca slice.
+
+The kit-of-one unification made u1_slice_workflow a dispatcher, so the two old
+slice_workflow integration tests now only assert the dispatch. This restores a
+full-chain check at the CURRENT entry point: run_kit_workflow analyzes a single
+STL, slices it with real OrcaSlicer, and produces a gated plate, and the
+resulting gcode carries the machine + material the upload gate keys on. Only the
+Moonraker upload is mocked (no printer contact).
+
+Runs where a real Orca binary exists (inside the Hermes runtime); skips in the
+dev container (Alpine/musl can't exec the glibc binary); same gate as
+test_real_orca_u1_metadata_e2e. LOCAL test (not on the public branch): it needs
+the runtime's Orca + fetched stock profiles.
+"""
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from u1_orient import DEFAULT_ORCA, write_binary_stl
+from u1_upload_gcode import parse_gcode_metadata
+import u1_kit_workflow as kw
+import u1_request
+
+from test_advanced_overrides_e2e import _cube_tris
+
+pytestmark = pytest.mark.skipif(
+    not DEFAULT_ORCA.exists(),
+    reason="real Orca binary not present in this environment",
+)
+
+
+def _single_stl_zip(tmp_path: Path) -> Path:
+    stl = tmp_path / "cube.stl"
+    write_binary_stl(stl, _cube_tris(15.0), name="cube")
+    zp = tmp_path / "one.zip"
+    with zipfile.ZipFile(zp, "w") as z:
+        z.write(stl, "cube.stl")
+    return zp
+
+
+def _args(model, out_dir, **over):
+    base = dict(model=str(model), json_events=True, form_answers=None,
+                form_answers_json=None, request_id=None, fresh=True,
+                operator="test:unit", nozzle="0.4", out_dir=str(out_dir),
+                live_upload=False, on_collision=None, no_live_material=True)
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def test_kit_workflow_real_orca_slice_produces_gated_gcode(tmp_path, monkeypatch):
+    try:
+        kw.profile_path("0_20_standard_snapmaker_u1_0_4_nozzle")
+    except Exception as exc:
+        pytest.skip(f"runtime profiles not fetched here ({exc})")
+
+    # Mock ONLY the Moonraker upload; no printer contact. Real slice runs.
+    monkeypatch.setattr(kw, "_real_upload", lambda gcode, on_collision=None,
+                        material=None: {"uploaded_filename": Path(gcode).name,
+                                        "moonraker_upload_ok": True,
+                                        "returncode": 0})
+
+    zp = _single_stl_zip(tmp_path)
+    res = kw.run_kit_workflow(_args(
+        zp, tmp_path / "out",
+        form_answers="all | T0 | PETG | 0.20 Standard | no-supports | upload-only",
+    ))
+
+    rid = res.get("request_id")
+    assert rid, f"no request_id in result: {res}"
+    req = u1_request.read_request(rid)
+    plates = req.get("plates") or []
+    assert plates, f"no plates recorded; phase={res.get('phase')}, res={res}"
+
+    plate = Path(plates[0]["gcode_path"])
+    assert plate.exists() and plate.stat().st_size > 0, "real gcode not produced"
+
+    # The gate's own parser: if these pass, the upload gate's printer/material
+    # blockers pass for this file.
+    meta = parse_gcode_metadata(plate)["metadata"]
+    assert "snapmaker u1" in meta.get("printer_settings_id", "").lower(), meta
+    assert "PETG" in meta.get("filament_type", "").upper(), meta

--- a/tests/test_u1_gcode_preview.py
+++ b/tests/test_u1_gcode_preview.py
@@ -1,0 +1,173 @@
+"""Toolpath truth preview (u1_gcode_preview): parse, project, color, render.
+
+The 3D review image draws the real toolpaths from the sliced gcode, so
+supports are visible, the print pose matches what the printer will run, and
+nothing is re-sliced to make the picture. These cover the gcode parse (M486
+instance attribution, ;TYPE: category mapping, arcs, metadata), the
+isometric projection's z direction (the first cut drew prints upside down),
+and the shared part-to-color map the footprint renderer also uses.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import u1_gcode_preview as gp
+
+
+def _gcode(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "plate.gcode"
+    p.write_text(body)
+    return p
+
+
+_TWO_PART_GCODE = """\
+; total filament used [g] = 12.34
+; estimated printing time (normal mode) = 1h 2m 3s
+M486 S0
+M486 Aobj_1_left.stl_id_0_copy_0
+M486 S1
+M486 Aobj_2_right.stl_id_1_copy_0
+M486 S-1
+M486 S0
+G1 X0 Y0 F3000
+G1 Z0.2
+;TYPE:Brim
+G1 X10 Y0 E1
+;TYPE:Outer wall
+G1 X10 Y10 E1
+;TYPE:Support
+G1 X0 Y10 E1
+;TYPE:Sparse infill
+G1 X5 Y5 E1
+G1 Z5.0
+;TYPE:Top surface
+G1 X0 Y0 E1
+M486 S-1
+M486 S1
+G1 X100 Y100 F3000
+G1 Z0.2
+;TYPE:Outer wall
+G1 X110 Y100 E1
+G1 X110 Y110 E1
+M486 S-1
+"""
+
+
+# ---------- parse ----------
+
+def test_parse_maps_types_and_keeps_full_instance_names(tmp_path):
+    parsed = gp.parse_toolpaths(_gcode(tmp_path, _TWO_PART_GCODE))
+    cats = [s[2] for s in parsed["segments"]]
+    assert "brim" in cats and "support" in cats and "top" in cats
+    assert "outer" in cats
+    # Sparse infill is interior noise at preview scale and must be dropped.
+    assert len(parsed["segments"]) == 6
+    # Full M486 instance names, exactly what the footprint renderer keys on.
+    assert parsed["parts"] == ["obj_1_left.stl_id_0_copy_0",
+                               "obj_2_right.stl_id_1_copy_0"]
+
+
+def test_parse_reads_filament_and_time_metadata(tmp_path):
+    meta = gp.parse_toolpaths(_gcode(tmp_path, _TWO_PART_GCODE))["meta"]
+    assert meta["filament_g"] == "12.34"
+    assert meta["time"] == "1h 2m 3s"
+
+
+def test_parse_attributes_segments_to_the_active_part(tmp_path):
+    parsed = gp.parse_toolpaths(_gcode(tmp_path, _TWO_PART_GCODE))
+    by_part: dict = {}
+    for _z, _seq, _cat, part, *_ in parsed["segments"]:
+        by_part.setdefault(part, 0)
+        by_part[part] += 1
+    assert by_part["obj_1_left.stl_id_0_copy_0"] == 4
+    assert by_part["obj_2_right.stl_id_1_copy_0"] == 2
+
+
+def test_parse_flattens_arcs_to_chords(tmp_path):
+    body = """\
+M486 S0
+M486 Aobj_1_arc.stl_id_0_copy_0
+M486 S-1
+M486 S0
+G1 X10 Y0 F3000
+G1 Z0.2
+;TYPE:Outer wall
+G3 X0 Y10 I-10 J0 E1
+M486 S-1
+"""
+    parsed = gp.parse_toolpaths(_gcode(tmp_path, body))
+    # A quarter arc of r=10 must land as multiple chords, not one line.
+    assert len(parsed["segments"]) > 3
+    end = parsed["segments"][-1]
+    assert abs(end[6] - 0) < 0.5 and abs(end[7] - 10) < 0.5
+
+
+def test_travel_and_untyped_moves_produce_no_segments(tmp_path):
+    body = """\
+M486 S0
+M486 Aobj_1_x.stl_id_0_copy_0
+M486 S-1
+M486 S0
+G1 X0 Y0 F3000
+G1 X50 Y50
+G1 X60 Y60 E1
+M486 S-1
+"""
+    # The E move has no ;TYPE: label yet, so it stays uncategorized.
+    assert gp.parse_toolpaths(_gcode(tmp_path, body))["segments"] == []
+
+
+# ---------- projection ----------
+
+def test_iso_projection_z_raises_points():
+    """Higher z must raise a point on screen. The first cut subtracted z and
+    drew every print upside down; the operator caught it on review."""
+    _u0, v0 = gp._iso(50, 50, 0)
+    _u1, v1 = gp._iso(50, 50, 30)
+    assert v1 > v0
+
+
+def test_iso_projection_depth_raises_points():
+    """Farther from the viewer corner (larger x + y) also raises a point,
+    which is what makes the bed grid read as receding."""
+    _u0, v0 = gp._iso(0, 0, 0)
+    _u1, v1 = gp._iso(100, 100, 0)
+    assert v1 > v0
+
+
+# ---------- shared colors ----------
+
+def test_part_colors_matches_the_footprint_formula():
+    import colorsys
+    names = ["b_part", "a_part", "c_part"]
+    colors = gp.part_colors(names)
+    ordered = sorted(names)
+    for i, name in enumerate(ordered):
+        r, g, b = colorsys.hsv_to_rgb(i / len(ordered), 0.55, 0.9)
+        assert colors[name] == (int(r * 255), int(g * 255), int(b * 255))
+
+
+def test_part_colors_is_order_independent():
+    a = gp.part_colors(["x_1", "y_2", "z_3"])
+    b = gp.part_colors(["z_3", "x_1", "y_2"])
+    assert a == b
+
+
+# ---------- render ----------
+
+def test_render_writes_png_and_reports_supports(tmp_path):
+    out = tmp_path / "iso.png"
+    res = gp.render_iso_preview(_gcode(tmp_path, _TWO_PART_GCODE), out)
+    assert res["ok"], res
+    assert out.exists() and out.stat().st_size > 0
+    assert res["support_segments"] == 1
+    assert res["meta"]["filament_g"] == "12.34"
+    assert res["parts"] == ["obj_1_left.stl_id_0_copy_0",
+                            "obj_2_right.stl_id_1_copy_0"]
+
+
+def test_render_fails_soft_on_empty_gcode(tmp_path):
+    out = tmp_path / "iso.png"
+    res = gp.render_iso_preview(_gcode(tmp_path, "; nothing here\n"), out)
+    assert not res["ok"]
+    assert not out.exists()

--- a/tests/test_u1_gcode_preview.py
+++ b/tests/test_u1_gcode_preview.py
@@ -171,3 +171,16 @@ def test_render_fails_soft_on_empty_gcode(tmp_path):
     res = gp.render_iso_preview(_gcode(tmp_path, "; nothing here\n"), out)
     assert not res["ok"]
     assert not out.exists()
+
+
+def test_chrome_free_render_for_thumbnails(tmp_path):
+    """chrome=False drops the header and footer text: the printer
+    touchscreen shows this at 48 and 300 px, where text is just noise."""
+    out = tmp_path / "thumb.png"
+    res = gp.render_iso_preview(_gcode(tmp_path, _TWO_PART_GCODE), out,
+                                canvas_px=600, chrome=False,
+                                title="ignored when chrome is off")
+    assert res["ok"], res
+    assert out.exists() and out.stat().st_size > 0
+    from PIL import Image
+    assert Image.open(out).size == (600, 600)

--- a/tests/test_u1_gcode_preview.py
+++ b/tests/test_u1_gcode_preview.py
@@ -184,3 +184,22 @@ def test_chrome_free_render_for_thumbnails(tmp_path):
     assert out.exists() and out.stat().st_size > 0
     from PIL import Image
     assert Image.open(out).size == (600, 600)
+
+
+def test_top_view_renders_full_bed_with_shared_styling(tmp_path):
+    """The top-down placement view draws the same toolpaths with the same
+    part colors as the 3D view, over the full bed."""
+    out = tmp_path / "top.png"
+    res = gp.render_top_preview(_gcode(tmp_path, _TWO_PART_GCODE), out,
+                                title="Plate 1 of 1",
+                                label_below="2 parts, T0 PETG")
+    assert res["ok"], res
+    assert res["part_count"] == 2
+    assert res["support_segments"] == 1
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_top_view_fails_soft_on_empty_gcode(tmp_path):
+    res = gp.render_top_preview(_gcode(tmp_path, "; nothing\n"),
+                                tmp_path / "top.png")
+    assert not res["ok"]

--- a/tests/test_u1_kit_workflow.py
+++ b/tests/test_u1_kit_workflow.py
@@ -986,3 +986,39 @@ def test_m486_top_down_renderer_survives_missing_shared_colors(tmp_path, monkeyp
         _plate_gcode(tmp_path), out)
     assert res["ok"], res
     assert res["part_count"] == 2
+
+
+def test_injected_thumbnail_prefers_the_3d_toolpath_view(tmp_path):
+    """The printer touchscreen thumbnail comes from the chrome-free 3D
+    toolpath render, with the top-down as fallback (operator request:
+    the machine's screen shows the print pose with supports)."""
+    gcode = _plate_gcode(tmp_path)
+    layout, injection = kw._render_and_inject_plate_preview(
+        gcode, 1, 1, tmp_path, arranged_stls=[], selected_count=2,
+        tool_choice="T0", material="PETG", bed_mm=(270.0, 270.0))
+    assert layout["ok"], layout
+    assert injection["ok"], injection
+    assert injection["thumbnail_source"].endswith("plate_1_iso_thumb.png")
+    assert "; thumbnail begin" in gcode.read_text()[:6000]
+    assert (tmp_path / "plate_1_iso.png").exists()
+
+
+def test_injected_thumbnail_falls_back_to_top_down(tmp_path, monkeypatch):
+    """When the toolpath render is unavailable the top-down still gets
+    injected, so the printer never loses its file preview."""
+    import builtins
+    real_import = builtins.__import__
+
+    def _no_preview(name, *a, **k):
+        if name == "u1_gcode_preview":
+            raise ImportError("simulated missing module")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", _no_preview)
+    gcode = _plate_gcode(tmp_path)
+    layout, injection = kw._render_and_inject_plate_preview(
+        gcode, 1, 1, tmp_path, arranged_stls=[], selected_count=2,
+        tool_choice="T0", material="PETG", bed_mm=(270.0, 270.0))
+    assert layout["ok"], layout
+    assert injection["ok"], injection
+    assert injection["thumbnail_source"].endswith("plate_1_preview.png")

--- a/tests/test_u1_kit_workflow.py
+++ b/tests/test_u1_kit_workflow.py
@@ -915,3 +915,74 @@ def test_reslice_clears_stale_pending_when_bed_capture_fails(
     safety = u1_request.read_request(rid).get("safety") or {}
     assert "pending_bed_clear_start" not in safety, (
         "a failed re-slice must not leave the prior slice's pending prompt")
+
+
+# --------------------------------------------------------------------------- #
+# The review renderers must actually EXECUTE in tests. The shared-colors
+# change left the top-down's part_count variable bound only in an import
+# fallback, so every successful render died at its return statement and took
+# the whole kit flow down after kit_sliced (live 2026-07-22). Nothing in the
+# suite ran the function, so 1093 tests stayed green around a crash on the
+# happy path. These render a real (synthetic) plate gcode end to end.
+# --------------------------------------------------------------------------- #
+
+_RENDER_GCODE = """\
+M486 S0
+M486 Aobj_1_left.stl_id_0_copy_0
+M486 S1
+M486 Aobj_2_right.stl_id_1_copy_0
+M486 S-1
+M486 S0
+G1 X50 Y50 F3000
+G1 Z0.2
+;TYPE:Outer wall
+G1 X70 Y50 E1
+G1 X70 Y70 E1
+G1 X50 Y70 E1
+G1 X50 Y50 E1
+M486 S-1
+M486 S1
+G1 X150 Y150 F3000
+G1 Z0.2
+;TYPE:Outer wall
+G1 X170 Y150 E1
+G1 X170 Y170 E1
+G1 X150 Y170 E1
+G1 X150 Y150 E1
+M486 S-1
+"""
+
+
+def _plate_gcode(tmp_path):
+    p = tmp_path / "plate_1.gcode"
+    p.write_text(_RENDER_GCODE)
+    return p
+
+
+def test_m486_top_down_renderer_runs_end_to_end(tmp_path):
+    out = tmp_path / "top.png"
+    res = kw._render_plate_layout_from_m486_outer_walls(
+        _plate_gcode(tmp_path), out, title="2 parts")
+    assert res["ok"], res
+    assert res["part_count"] == 2
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_m486_top_down_renderer_survives_missing_shared_colors(tmp_path, monkeypatch):
+    """The shared color import must stay optional: with u1_gcode_preview
+    unimportable the inline fallback colors the parts and the render still
+    succeeds with the same part_count."""
+    import builtins
+    real_import = builtins.__import__
+
+    def _no_preview(name, *a, **k):
+        if name == "u1_gcode_preview":
+            raise ImportError("simulated missing module")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", _no_preview)
+    out = tmp_path / "top.png"
+    res = kw._render_plate_layout_from_m486_outer_walls(
+        _plate_gcode(tmp_path), out)
+    assert res["ok"], res
+    assert res["part_count"] == 2


### PR DESCRIPTION
## Summary

The v3.0.0 bundle: review images drawn from the real toolpaths, and Hermes integration that survives Hermes upgrades. No breaking changes; nothing to migrate. Every change here has been proven with live kit runs on the operator box, including a multi-plate kit and a live upload to the printer.

### Reviews show ground truth

- **Both review images render straight from the sliced G-code the printer will run.** The 3D view shows the true print pose with supports in their own color; the top-down keeps the bed grid and mm labels for placement but now draws the real geometry, so a part actually looks like itself from above. Part colors match across both images, and the numbers on the card (filament grams, print time) come from the same file. Nothing is re-sliced to make a picture, so the images cannot drift from the plan.
- **The printer's screen shows the 3D view.** The thumbnail embedded in each plate's G-code is a clean geometry-only render of the toolpath view.
- The old silhouette renderers stay as automatic fallbacks at every step.

### Integration survives upgrades

- **Kit detection works mid-conversation.** Detection now rides the message itself as well as the session plumbing, explicitly overrides a newer Hermes attachment note that steered the model toward unpacking the file by hand, and logs loudly when a document matches nothing.
- **The form callback is published by the plugin on every message** instead of relying on a patched Hermes file that package upgrades silently replace. The patch remains as a fallback for older builds; the installer no longer aborts when it cannot apply it.

### Hardening

- Fixed a renderer crash that could stop a kit after slicing, and closed the coverage gap that let it through: the renderers now have tests that execute them for real, plus a full end-to-end kit slice test that runs wherever the runtime OrcaSlicer exists (self-skips elsewhere).

## Test

Full suite green (1100 passed, 8 skipped). Live validation on the operator box: mid-session kit detection, a multi-plate kit (3 plates), a live printer upload with the new thumbnail, and the two-stage start gate with cancel exercised end to end.
