### PR TITLE
Close the printer-preview race: quantized thumbnails, blocking metascan

### DIFF
--- a/scripts/u1_kit_workflow.py
+++ b/scripts/u1_kit_workflow.py
@@ -1454,6 +1454,16 @@ def _inject_plate_thumbnail(gcode_path: Path, preview_png_path: Path,
     for (w, h) in sizes:
         try:
             scaled = base.resize((w, h))
+            # Palette-quantize before encoding: the toolpath renders are
+            # dense texture that defeats RGB PNG compression (a 300 px
+            # thumb ran 50 KB encoded vs 12 KB quantized, with no visible
+            # cost on these flat-color images). Smaller header blocks parse
+            # faster everywhere and shrink the window where the printer's
+            # screen asks for a preview mid-scan. Fail-open to RGB.
+            try:
+                scaled = scaled.quantize(colors=64)
+            except Exception:
+                pass
             blocks.append(encode_thumbnail_block(scaled))
             sizes_used.append((w, h))
         except Exception:

--- a/scripts/u1_upload_gcode.py
+++ b/scripts/u1_upload_gcode.py
@@ -45,6 +45,37 @@ def http_json(url: str, timeout: float = 12.0) -> dict[str, Any]:
         return json.loads(r.read().decode("utf-8"))
 
 
+def fetch_remote_metadata(host: str, port: int, filename: str) -> dict[str, Any]:
+    """Post-upload metadata, scanned to completion when the printer allows.
+
+    Moonraker parses a large file's metadata (thumbnails included)
+    asynchronously after upload; the touchscreen and app can ask for the
+    preview in that window, get nothing, and cache the miss for that
+    filename (live 2026-07-22 on 50 MB plates: generic icons that never
+    healed). POST /server/files/metascan forces the scan and BLOCKS until
+    it finishes, so by the time the workflow announces the upload the
+    thumbnails are queryable. Older Moonraker builds without the endpoint
+    fall back to the plain metadata GET, which is the previous behavior.
+    """
+    try:
+        req = urllib.request.Request(
+            f"{base_url(host, port)}/server/files/metascan",
+            data=json.dumps({"filename": filename}).encode(),
+            headers={"Content-Type": "application/json"}, method="POST")
+        with urllib.request.urlopen(req, timeout=90.0) as r:
+            meta = json.loads(r.read().decode("utf-8")).get("result", {})
+        if meta:
+            return meta
+    except Exception:
+        pass  # endpoint absent or scan failed; the GET below still answers
+    try:
+        return http_json(
+            f"{base_url(host, port)}/server/files/metadata?filename="
+            f"{urllib.parse.quote(filename)}").get("result", {})
+    except Exception:
+        return {}
+
+
 def base_url(host: str, port: int) -> str:
     return f"http://{host}:{port}"
 
@@ -534,7 +565,7 @@ def main() -> int:
         after_blockers.append(f"Moonraker indicated print start/queue: {response}")
 
     remote_name = uploaded_filename
-    metadata = http_json(f"{base_url(host,port)}/server/files/metadata?filename={urllib.parse.quote(remote_name)}").get("result", {})
+    metadata = fetch_remote_metadata(host, port, remote_name)
     remote_metadata_ok = bool(metadata)
     # Moonraker's /server/files/upload response can be EITHER wrapped (with
     # a top-level "result" key, Moonraker JSON-RPC convention) OR unwrapped

--- a/tests/test_u1_kit_workflow.py
+++ b/tests/test_u1_kit_workflow.py
@@ -1022,3 +1022,33 @@ def test_injected_thumbnail_falls_back_to_top_down(tmp_path, monkeypatch):
     assert layout["ok"], layout
     assert injection["ok"], injection
     assert injection["thumbnail_source"].endswith("plate_1_preview.png")
+
+
+def test_injected_thumbnails_are_palette_quantized(tmp_path):
+    """Dense toolpath renders defeat RGB PNG compression; the injected
+    blocks must be palette-quantized so header size stays in the range the
+    printer's screen parses promptly (live 2026-07-22: 50KB headers on a
+    50MB file raced the metadata scan and the app cached a missing
+    preview)."""
+    import io, base64, re as _re
+    from PIL import Image
+    import random
+    rng = random.Random(7)
+    noisy = Image.new("RGB", (600, 600))
+    noisy.putdata([(rng.randrange(256), rng.randrange(256), rng.randrange(256))
+                   for _ in range(600 * 600)])
+    png = tmp_path / "thumb.png"
+    noisy.save(png)
+    gcode = tmp_path / "plate.gcode"
+    gcode.write_text("; HEADER_BLOCK_START\nG28\n")
+    res = kw._inject_plate_thumbnail(gcode, png)
+    assert res["ok"], res
+    text = gcode.read_text()
+    m = _re.search(r"; thumbnail begin 300x300 (\d+)", text)
+    assert m, "300px block missing"
+    quant_len = int(m.group(1))
+    # The same image encoded RGB for comparison.
+    buf = io.BytesIO()
+    noisy.resize((300, 300)).save(buf, format="PNG", optimize=True)
+    rgb_len = len(base64.b64encode(buf.getvalue()))
+    assert quant_len < rgb_len * 0.6, (quant_len, rgb_len)

--- a/tests/test_upload_metascan.py
+++ b/tests/test_upload_metascan.py
@@ -1,0 +1,60 @@
+"""Post-upload metadata must come from a completed scan, not a racing GET.
+
+Moonraker parses a large file's metadata asynchronously after upload; the
+printer's screen can ask for the thumbnail in that window and cache the
+miss. fetch_remote_metadata forces the scan via /server/files/metascan and
+falls back to the plain GET on older Moonraker builds."""
+from __future__ import annotations
+
+import json
+
+import u1_upload_gcode as up
+
+
+class _Resp:
+    def __init__(self, payload):
+        self._p = json.dumps(payload).encode()
+
+    def read(self):
+        return self._p
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_metascan_result_wins(monkeypatch):
+    calls = []
+
+    def fake_urlopen(req, timeout=None):
+        url = req if isinstance(req, str) else req.full_url
+        calls.append(url)
+        assert "metascan" in url
+        return _Resp({"result": {"size": 5, "thumbnails": [{"width": 300}]}})
+
+    monkeypatch.setattr(up.urllib.request, "urlopen", fake_urlopen)
+    meta = up.fetch_remote_metadata("h", 7125, "big_plate.gcode")
+    assert meta.get("thumbnails")
+    assert len(calls) == 1  # no fallback GET needed
+
+
+def test_falls_back_to_get_when_metascan_absent(monkeypatch):
+    def fake_urlopen(req, timeout=None):
+        url = req if isinstance(req, str) else req.full_url
+        if "metascan" in url:
+            raise OSError("404")
+        return _Resp({"result": {"size": 5}})
+
+    monkeypatch.setattr(up.urllib.request, "urlopen", fake_urlopen)
+    meta = up.fetch_remote_metadata("h", 7125, "big_plate.gcode")
+    assert meta == {"size": 5}
+
+
+def test_returns_empty_when_everything_fails(monkeypatch):
+    def fake_urlopen(req, timeout=None):
+        raise OSError("printer offline")
+
+    monkeypatch.setattr(up.urllib.request, "urlopen", fake_urlopen)
+    assert up.fetch_remote_metadata("h", 7125, "x.gcode") == {}


### PR DESCRIPTION
Big plates surfaced a race in the printer's own UI: Moonraker parses an uploaded file's metadata asynchronously, the touchscreen and app request the thumbnail while the scan is still running on a 50 MB file, and the miss gets cached as a generic icon. Proven live by re-uploading identical bytes under a fresh name, which displayed fine.

- Injected thumbnails are palette-quantized (a 300 px block dropped from 50 KB to 12 KB with no visible cost), so headers parse faster everywhere.
- The upload step forces the metadata scan and waits for it (/server/files/metascan) before reporting, with a fallback to the plain GET on older Moonraker builds.

Full suite green (1105 passed, 8 skipped). Deployed and verified on the operator box; the affected files were healed in place.